### PR TITLE
Adding Account Login Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 itertools = "0.10.1"
+http = "0.2.4"
 serde_json = "1.0.67"
 thiserror = "1.0.28"
 

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod books;
 
 #[cfg(test)]

--- a/src/clients/account.rs
+++ b/src/clients/account.rs
@@ -1,0 +1,42 @@
+use crate::models::account::{LoginRequest, Session};
+use crate::{ErrorResponse, OpenLibraryError};
+use reqwest::{Client, StatusCode};
+use std::convert::TryFrom;
+
+pub struct AccountClient {
+    pub client: Client,
+}
+
+impl AccountClient {
+    const BASE_URL: &'static str = "https://openlibrary.org/account/login";
+
+    pub fn new(client: &Client) -> Self {
+        Self {
+            client: client.clone(),
+        }
+    }
+
+    pub async fn login(
+        self,
+        username: String,
+        password: String,
+    ) -> Result<Session, OpenLibraryError> {
+        let response = self
+            .client
+            .post(AccountClient::BASE_URL)
+            .json(&LoginRequest { username, password })
+            .send()
+            .await
+            .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
+
+        match response.status() {
+            StatusCode::OK => Ok(Session::try_from(response))?,
+            _ => Err(OpenLibraryError::ApiError {
+                response: response
+                    .json::<ErrorResponse>()
+                    .await
+                    .map_err(|err| OpenLibraryError::JsonParseError { source: err })?,
+            }),
+        }
+    }
+}

--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -11,8 +11,10 @@ pub struct BooksClient {
 impl BooksClient {
     const BASE_URL: &'static str = "https://openlibrary.org/api/books";
 
-    pub fn new(client: Client) -> Self {
-        Self { client }
+    pub fn new(client: &Client) -> Self {
+        Self {
+            client: client.clone(),
+        }
     }
 
     pub async fn search(

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -1,16 +1,19 @@
 use crate::models::books::{BookIdentifier, BookIdentifierKey};
 use crate::OpenLibraryClient;
+use std::error::Error;
 
 #[tokio::test]
-async fn verify_search_call() {
+async fn verify_search_call() -> Result<(), Box<dyn Error>> {
     //TODO: get wiremock working for unit tests
-    let client = OpenLibraryClient::new().unwrap();
+    let client = OpenLibraryClient::builder().build()?;
     let results = client
         .books
         .search(vec![
             &BookIdentifier::from(BookIdentifierKey::ISBN, "0451526538".to_string()),
             &BookIdentifier::from(BookIdentifierKey::GoodReads, "0451526538".to_string()),
         ])
-        .await;
-    assert_eq!(results.unwrap().len(), 1)
+        .await?;
+
+    assert_eq!(results.len(), 1);
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
+use crate::clients::account::AccountClient;
+use crate::models::account::Session;
 use clients::books::BooksClient;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::ClientBuilder;
-use std::fmt::Debug;
+use serde::Deserialize;
+use std::fmt::{Debug, Display, Formatter};
 use thiserror::Error;
 
 mod clients;
@@ -11,29 +14,109 @@ mod tests;
 
 #[derive(Debug, Error)]
 pub enum OpenLibraryError {
+    #[error("Received an error response from the Open Library API: {}", response)]
+    ApiError { response: ErrorResponse },
     #[error("Unable to build HTTP client: {}", source)]
     ClientBuildingError { source: reqwest::Error },
     #[error("An error occurred while parsing json: {}", source)]
     JsonParseError { source: reqwest::Error },
+    #[error(
+        "The operation ({}) requires authentication to be provided!",
+        operation
+    )]
+    NotAuthenticated { operation: String },
     #[error("An error occurred while trying to parse a value: {}", reason)]
     ParsingError { reason: String },
     #[error("An error occurred while sending HTTP request: {}", source)]
     RequestFailed { source: reqwest::Error },
 }
 
-pub struct OpenLibraryClient {
-    pub books: BooksClient,
+#[derive(Debug, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
 }
 
-impl OpenLibraryClient {
-    pub fn new() -> Result<OpenLibraryClient, OpenLibraryError> {
+impl Display for ErrorResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+pub struct OpenLibraryAuthClient {
+    account: AccountClient,
+}
+
+impl OpenLibraryAuthClient {
+    pub fn new() -> Result<OpenLibraryAuthClient, OpenLibraryError> {
         let client = ClientBuilder::new()
-            .default_headers(HeaderMap::new())
             .build()
             .map_err(|error| OpenLibraryError::ClientBuildingError { source: error })?;
 
         Ok(Self {
-            books: BooksClient::new(client),
+            account: AccountClient { client },
+        })
+    }
+
+    pub async fn login(
+        self,
+        username: String,
+        password: String,
+    ) -> Result<Session, OpenLibraryError> {
+        self.account.login(username, password).await
+    }
+}
+
+pub struct OpenLibraryClient {
+    pub account: AccountClient,
+    pub books: BooksClient,
+}
+
+impl OpenLibraryClient {
+    pub fn builder() -> OpenLibraryClientBuilder {
+        OpenLibraryClientBuilder::new()
+    }
+}
+
+pub struct OpenLibraryClientBuilder {
+    session: Option<Session>,
+}
+
+impl OpenLibraryClientBuilder {
+    fn new() -> OpenLibraryClientBuilder {
+        OpenLibraryClientBuilder { session: None }
+    }
+
+    pub fn with_session(self, session: Session) -> OpenLibraryClientBuilder {
+        OpenLibraryClientBuilder {
+            session: Some(session),
+        }
+    }
+
+    pub fn build(self) -> Result<OpenLibraryClient, OpenLibraryError> {
+        let default_headers = match self.session.clone() {
+            Some(session) => {
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    "Cookie",
+                    HeaderValue::from_str(session.cookie.as_str()).map_err(|_error| {
+                        OpenLibraryError::ParsingError {
+                            reason: "Unable to parse session cookie into header value".to_string(),
+                        }
+                    })?,
+                );
+                headers
+            }
+            None => HeaderMap::new(),
+        };
+
+        let client = ClientBuilder::new()
+            .default_headers(default_headers)
+            .build()
+            .map_err(|error| OpenLibraryError::ClientBuildingError { source: error })?;
+
+        Ok(OpenLibraryClient {
+            books: BooksClient::new(&client),
+            account: AccountClient::new(&client),
         })
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod books;
 
 #[cfg(test)]

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -1,0 +1,36 @@
+use crate::OpenLibraryError;
+use reqwest::Response;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+#[derive(Serialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct Session {
+    pub cookie: String,
+}
+
+impl TryFrom<Response> for Session {
+    type Error = OpenLibraryError;
+
+    fn try_from(response: Response) -> Result<Self, Self::Error> {
+        let cookie = response
+            .headers()
+            .get(http::header::SET_COOKIE)
+            .ok_or(OpenLibraryError::ParsingError {
+                reason: "The API response from Open Library did not include a Set-Cookie header"
+                    .to_string(),
+            })?
+            .to_str()
+            .map_err(|_e| OpenLibraryError::ParsingError {
+                reason: "Unable to parse Set-Cookie Header Value into String".to_string(),
+            })?
+            .to_string();
+
+        Ok(Self { cookie })
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 extern crate open_library;
 use open_library::models::books::{BookIdentifier, BookIdentifierKey};
-use open_library::OpenLibraryClient;
+use open_library::{OpenLibraryAuthClient, OpenLibraryClient};
 
 #[tokio::test]
 async fn verify_identifier_values() -> Result<(), Box<dyn std::error::Error>> {
-    let client = OpenLibraryClient::new()?;
+    let client = OpenLibraryClient::builder().build()?;
     let identifier = BookIdentifier::from(BookIdentifierKey::ISBN, "0374386137".to_string());
     let book_results = client.books.search(vec![&identifier]).await?;
     let book = book_results
@@ -12,6 +12,17 @@ async fn verify_identifier_values() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or(format!("No book found with identifier {}", identifier))?;
 
     assert_eq!(book.title, "A Wrinkle in Time");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn verify_authed_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    let auth_client = OpenLibraryAuthClient::new()?;
+    let username = std::env::var("OPEN_LIBRARY_USERNAME")?;
+    let password = std::env::var("OPEN_LIBRARY_PASSWORD")?;
+    let session = auth_client.login(username, password).await?;
+    let _client = OpenLibraryClient::builder().with_session(session).build()?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description 

Some endpoints within the Open Library API require authentication (pulling from private Reading Log). Adding the ability to specify credentials and get back a Session Cookie (via `OpenLibraryAuthClient`) to specify in subsequent requests.

Closes #3 