### PR TITLE
Identifier Refactor & Wiremock Setup

### DIFF
--- a/src/clients/account.rs
+++ b/src/clients/account.rs
@@ -5,11 +5,11 @@ use url::Url;
 
 pub struct AccountClient {
     pub client: Client,
-    pub host: String,
+    pub host: Url,
 }
 
 impl AccountClient {
-    pub fn new(client: &Client, host: &String) -> Self {
+    pub fn new(client: &Client, host: &Url) -> Self {
         Self {
             client: client.clone(),
             host: host.clone(),
@@ -23,13 +23,11 @@ impl AccountClient {
     ) -> Result<Session, OpenLibraryError> {
         let response = self
             .client
-            .post(
-                Url::parse(format!("{}/account/login", self.host).as_str()).map_err(|error| {
-                    OpenLibraryError::InternalError {
-                        reason: error.to_string(),
-                    }
-                })?,
-            )
+            .post(self.host.join("/account/login").map_err(|error| {
+                OpenLibraryError::InternalError {
+                    reason: error.to_string(),
+                }
+            })?)
             .json(&LoginRequest {
                 username: username.clone(),
                 password: password.clone(),
@@ -67,12 +65,11 @@ impl AccountClient {
         let response = self
             .client
             .get(
-                Url::parse(
-                    format!("{}/people/{}/books/want-to-read.json", self.host, username).as_str(),
-                )
-                .map_err(|_e| OpenLibraryError::ParsingError {
-                    reason: "Unable to parse into valid URL".to_string(),
-                })?,
+                self.host
+                    .join(format!("/people/{}/books/want-to-read.json", username).as_str())
+                    .map_err(|_e| OpenLibraryError::ParsingError {
+                        reason: "Unable to parse into valid URL".to_string(),
+                    })?,
             )
             .send()
             .await

--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -4,14 +4,15 @@ use http::StatusCode;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use url::Url;
 
 pub struct BooksClient {
     client: Client,
-    host: String,
+    host: Url,
 }
 
 impl BooksClient {
-    pub fn new(client: &Client, host: &String) -> Self {
+    pub fn new(client: &Client, host: &Url) -> Self {
         Self {
             client: client.clone(),
             host: host.clone(),
@@ -31,7 +32,13 @@ impl BooksClient {
 
         let response = self
             .client
-            .get(format!("{}/api/books", self.host))
+            .get(
+                self.host
+                    .join("/api/books")
+                    .map_err(|_e| OpenLibraryError::ParsingError {
+                        reason: "Unable to parse into valid URL".to_string(),
+                    })?,
+            )
             .query(&[
                 (QueryParameters::BibliographyKeys, &ids_filter),
                 (QueryParameters::Format, &String::from("json")),

--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -1,51 +1,29 @@
-use crate::models::books::{Book, BookIdentifier, BookIdentifierKey};
+use crate::models::books::{BibliographyKey, Book};
 use crate::OpenLibraryError;
-use itertools::{Either, Itertools};
+use http::StatusCode;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub struct BooksClient {
     client: Client,
+    host: String,
 }
 
 impl BooksClient {
-    const BASE_URL: &'static str = "https://openlibrary.org/api/books";
-
-    pub fn new(client: &Client) -> Self {
+    pub fn new(client: &Client, host: &String) -> Self {
         Self {
             client: client.clone(),
+            host: host.clone(),
         }
     }
 
     pub async fn search(
         self,
-        identifiers: Vec<&BookIdentifier>,
-    ) -> Result<HashMap<BookIdentifier, Book>, OpenLibraryError> {
-        let unsupported_identifier_keys = vec![
-            BookIdentifierKey::GoodReads,
-            BookIdentifierKey::LibraryThing,
-            BookIdentifierKey::ProjectGutenberg,
-        ];
-        let (supported_ids, unsupported_ids): (Vec<BookIdentifier>, Vec<BookIdentifier>) =
-            identifiers.into_iter().partition_map(|id| {
-                match unsupported_identifier_keys.contains(&id.clone().key) {
-                    true => Either::Right(id.clone()),
-                    false => Either::Left(id.clone()),
-                }
-            });
-
-        if !unsupported_ids.is_empty() {
-            println!("[WARNING] Some specified identifiers {:?} are not supported via Book Search, they will be ignored!",
-                     unsupported_ids);
-            tracing::warn!(
-                "Some specified identifiers {:?} are not supported via Book Search, they will be ignored!",
-                unsupported_ids
-            );
-        }
-
-        tracing::info!("Supported id: {:?}", &supported_ids);
-
-        let ids_filter = supported_ids
+        identifiers: Vec<&BibliographyKey>,
+    ) -> Result<HashMap<BibliographyKey, Book>, OpenLibraryError> {
+        // tracing::info!("Identifiers: {:?}", identifiers);
+        let ids_filter = identifiers
             .into_iter()
             .map(|id| id.to_string())
             .collect::<Vec<String>>()
@@ -53,21 +31,34 @@ impl BooksClient {
 
         let response = self
             .client
-            .get(BooksClient::BASE_URL)
+            .get(format!("{}/api/books", self.host))
             .query(&[
-                ("bibkeys", &ids_filter),
-                ("format", &"json".to_string()),
-                ("jscmd", &"data".to_string()),
+                (QueryParameters::BibliographyKeys, &ids_filter),
+                (QueryParameters::Format, &String::from("json")),
+                (QueryParameters::JavascriptCommand, &String::from("data")),
             ])
             .send()
             .await
             .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
 
-        let results: HashMap<BookIdentifier, Book> = response
-            .json::<HashMap<BookIdentifier, Book>>()
-            .await
-            .map_err(|error| OpenLibraryError::JsonParseError { source: error })?;
+        let results: HashMap<BibliographyKey, Book> = match response.status() {
+            StatusCode::OK => Ok(response
+                .json::<HashMap<BibliographyKey, Book>>()
+                .await
+                .map_err(|error| OpenLibraryError::JsonParseError { source: error })?),
+            _ => Err(OpenLibraryError::ApiError { response }),
+        }?;
 
         Ok(results)
     }
+}
+
+#[derive(Deserialize, Serialize)]
+enum QueryParameters {
+    #[serde(rename = "bibkeys")]
+    BibliographyKeys,
+    #[serde(rename = "format")]
+    Format,
+    #[serde(rename = "jscmd")]
+    JavascriptCommand,
 }

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -1,6 +1,7 @@
 use crate::models::books::{BibliographyKey, Book};
 use crate::{OpenLibraryClient, OpenLibraryError};
 use http::Method;
+use reqwest::Url;
 use std::collections::HashMap;
 use std::error::Error;
 use wiremock::matchers::{method, path, query_param};
@@ -10,7 +11,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 async fn test_book_search_returns_success() -> Result<(), Box<dyn Error>> {
     let server = MockServer::start().await;
     let client = OpenLibraryClient::builder()
-        .with_host(server.uri())
+        .with_host(Url::parse(server.uri().as_str())?)
         .build()?;
 
     let mock_response: HashMap<BibliographyKey, Book> =
@@ -42,7 +43,7 @@ async fn test_book_search_returns_success() -> Result<(), Box<dyn Error>> {
 async fn test_book_search_returns_failure_when_request_fails() -> Result<(), Box<dyn Error>> {
     let server = MockServer::start().await;
     let client = OpenLibraryClient::builder()
-        .with_host(server.uri())
+        .with_host(Url::parse(server.uri().as_str())?)
         .build()?;
 
     let key = BibliographyKey::ISBN("0201558025".to_string());

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -1,19 +1,73 @@
-use crate::models::books::{BookIdentifier, BookIdentifierKey};
-use crate::OpenLibraryClient;
+use crate::models::books::{BibliographyKey, Book};
+use crate::{OpenLibraryClient, OpenLibraryError};
+use http::Method;
+use std::collections::HashMap;
 use std::error::Error;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
-async fn verify_search_call() -> Result<(), Box<dyn Error>> {
-    //TODO: get wiremock working for unit tests
-    let client = OpenLibraryClient::builder().build()?;
-    let results = client
-        .books
-        .search(vec![
-            &BookIdentifier::from(BookIdentifierKey::ISBN, "0451526538".to_string()),
-            &BookIdentifier::from(BookIdentifierKey::GoodReads, "0451526538".to_string()),
-        ])
-        .await?;
+async fn test_book_search_returns_success() -> Result<(), Box<dyn Error>> {
+    let server = MockServer::start().await;
+    let client = OpenLibraryClient::builder()
+        .with_host(server.uri())
+        .build()?;
 
-    assert_eq!(results.len(), 1);
+    let mock_response: HashMap<BibliographyKey, Book> =
+        serde_json::from_str(include_str!("resources/book.json"))?;
+
+    let key = BibliographyKey::ISBN("0201558025".to_string());
+    let identifiers = vec![&key];
+    let ids_filter = identifiers
+        .clone()
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+
+    Mock::given(method(Method::GET.as_str()))
+        .and(path("/api/books"))
+        .and(query_param("bibkeys", &ids_filter))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&mock_response))
+        .mount(&server)
+        .await;
+
+    let actual = client.books.search(identifiers).await?;
+
+    assert_eq!(actual.keys().len(), 3);
     Ok(())
+}
+
+#[tokio::test]
+async fn test_book_search_returns_failure_when_request_fails() -> Result<(), Box<dyn Error>> {
+    let server = MockServer::start().await;
+    let client = OpenLibraryClient::builder()
+        .with_host(server.uri())
+        .build()?;
+
+    let key = BibliographyKey::ISBN("0201558025".to_string());
+    let identifiers = vec![&key];
+    let ids_filter = identifiers
+        .clone()
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+
+    Mock::given(method(Method::GET.as_str()))
+        .and(path("/api/books"))
+        .and(query_param("bibkeys", &ids_filter))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let actual = client.books.search(identifiers).await;
+    let error = actual.expect_err("Expected Book Search call to return an error but it didn't!");
+    match &error {
+        OpenLibraryError::ApiError { response: _ } => Ok(()),
+        _ => panic!(
+            "Expected to received an API error, but received {:?} instead!",
+            error
+        ),
+    }
 }

--- a/src/clients/tests/resources/book.json
+++ b/src/clients/tests/resources/book.json
@@ -1,0 +1,220 @@
+{
+  "ISBN:0201558025": {
+    "url": "http://openlibrary.org/books/OL1429049M/Concrete_mathematics",
+    "key": "/books/OL1429049M",
+    "title": "Concrete mathematics",
+    "subtitle": "a foundation for computer science",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL720958A/Ronald_L._Graham",
+        "name": "Ronald L. Graham"
+      },
+      {
+        "url": "http://openlibrary.org/authors/OL229501A/Donald_Knuth",
+        "name": "Donald Knuth"
+      },
+      {
+        "url": "http://openlibrary.org/authors/OL2669938A/Oren_Patashnik",
+        "name": "Oren Patashnik"
+      }
+    ],
+    "number_of_pages": 657,
+    "pagination": "xiii, 657 p. :",
+    "by_statement": "Ronald L. Graham, Donald E. Knuth, Oren Patashnik.",
+    "identifiers": {
+      "librarything": [
+        "45844"
+      ],
+      "wikidata": [
+        "Q15303722"
+      ],
+      "goodreads": [
+        "112243"
+      ],
+      "isbn_10": [
+        "0201558025"
+      ],
+      "lccn": [
+        "93040325"
+      ],
+      "openlibrary": [
+        "OL1429049M"
+      ]
+    },
+    "classifications": {
+      "lc_classifications": [
+        "QA39.2 .G733 1994",
+        "QA39.2.G733 1994"
+      ],
+      "dewey_decimal_class": [
+        "510"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Addison-Wesley"
+      }
+    ],
+    "publish_places": [
+      {
+        "name": "Reading, Mass"
+      }
+    ],
+    "publish_date": "1994",
+    "subjects": [
+      {
+        "name": "Computer science",
+        "url": "https://openlibrary.org/subjects/computer_science"
+      },
+      {
+        "name": "Mathematics",
+        "url": "https://openlibrary.org/subjects/mathematics"
+      },
+      {
+        "name": "Computer science, mathematics",
+        "url": "https://openlibrary.org/subjects/computer_science,_mathematics"
+      }
+    ],
+    "notes": "Includes bibliographical references (p. 604-631) and index.",
+    "ebooks": [
+      {
+        "preview_url": "https://archive.org/details/concretemathemat00grah_444",
+        "availability": "restricted",
+        "formats": {}
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/135182-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/135182-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/135182-L.jpg"
+    }
+  },
+  "LCCN:93005405": {
+    "url": "http://openlibrary.org/books/OL1397864M/Zen_speaks",
+    "key": "/books/OL1397864M",
+    "title": "Zen speaks",
+    "subtitle": "shouts of nothingness",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL223368A/Zhizhong_Cai",
+        "name": "Zhizhong Cai"
+      }
+    ],
+    "number_of_pages": 159,
+    "pagination": "159 p. :",
+    "identifiers": {
+      "librarything": [
+        "192819"
+      ],
+      "goodreads": [
+        "979250"
+      ],
+      "isbn_10": [
+        "0385472579"
+      ],
+      "lccn": [
+        "93005405"
+      ],
+      "openlibrary": [
+        "OL1397864M"
+      ]
+    },
+    "classifications": {
+      "lc_classifications": [
+        "BQ9265.6 .T7313 1994"
+      ],
+      "dewey_decimal_class": [
+        "294.3/927"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Anchor Books"
+      }
+    ],
+    "publish_places": [
+      {
+        "name": "New York"
+      }
+    ],
+    "publish_date": "1994",
+    "subjects": [
+      {
+        "name": "Caricatures and cartoons",
+        "url": "https://openlibrary.org/subjects/caricatures_and_cartoons"
+      },
+      {
+        "name": "Zen Buddhism",
+        "url": "https://openlibrary.org/subjects/zen_buddhism"
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/240726-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/240726-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/240726-L.jpg"
+    }
+  },
+  "OLID:OL32336498M": {
+    "url": "http://openlibrary.org/books/OL32336498M/Atomic_Habits",
+    "key": "/books/OL32336498M",
+    "title": "Atomic Habits",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL7422948A/James_Clear",
+        "name": "James Clear"
+      }
+    ],
+    "identifiers": {
+      "isbn_13": [
+        "9780735211308"
+      ],
+      "openlibrary": [
+        "OL32336498M"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Avery"
+      }
+    ],
+    "publish_date": "2018",
+    "subjects": [
+      {
+        "name": "Habit",
+        "url": "https://openlibrary.org/subjects/habit"
+      },
+      {
+        "name": "Habit breaking",
+        "url": "https://openlibrary.org/subjects/habit_breaking"
+      },
+      {
+        "name": "Behavior modification",
+        "url": "https://openlibrary.org/subjects/behavior_modification"
+      },
+      {
+        "name": "Self-actualization (psychology)",
+        "url": "https://openlibrary.org/subjects/self-actualization_(psychology)"
+      },
+      {
+        "name": "nyt:business-books=2020-07-12",
+        "url": "https://openlibrary.org/subjects/nyt:business-books=2020-07-12"
+      },
+      {
+        "name": "New York Times bestseller",
+        "url": "https://openlibrary.org/subjects/new_york_times_bestseller"
+      }
+    ],
+    "ebooks": [
+      {
+        "preview_url": "https://archive.org/details/atomic-habits-tiny-changes-remarkable-results-by-james-clear-z-lib.org",
+        "availability": "restricted",
+        "formats": {}
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/10958382-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/10958382-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/10958382-L.jpg"
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{ClientBuilder, Response};
 use std::fmt::Debug;
 use thiserror::Error;
+use url::Url;
 
 mod clients;
 mod format;
@@ -43,7 +44,7 @@ impl OpenLibraryAuthClient {
         Ok(Self {
             account: AccountClient {
                 client,
-                host: "https://openlibrary.org".to_string(),
+                host: Url::parse("https://openlibrary.org/").unwrap(),
             },
         })
     }
@@ -69,19 +70,19 @@ impl OpenLibraryClient {
 }
 
 pub struct OpenLibraryClientBuilder {
-    host: String, // TODO maybe should be URL
+    host: Url,
     session: Option<Session>,
 }
 
 impl OpenLibraryClientBuilder {
     fn new() -> OpenLibraryClientBuilder {
         OpenLibraryClientBuilder {
-            host: "https://openlibrary.org".to_string(),
+            host: Url::parse("https://openlibrary.org/").unwrap(),
             session: None,
         }
     }
 
-    pub fn with_host(self, host: String) -> OpenLibraryClientBuilder {
+    pub fn with_host(self, host: Url) -> OpenLibraryClientBuilder {
         OpenLibraryClientBuilder {
             host,
             session: self.session,

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,15 +8,13 @@ pub mod books;
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone)]
-pub struct Identifier {
-    pub resource: Resource,
+#[derive(Clone, Debug)]
+pub struct Identifier<T: OpenLibraryIdentifierKey> {
+    pub resource: T,
     pub identifier: String,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-#[serde(from = "Resource")]
-#[serde(into = "Resource")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Resource {
     #[serde(alias = "authors")]
     Author,
@@ -25,6 +23,9 @@ pub enum Resource {
     #[serde(alias = "works")]
     Work,
 }
+
+pub trait OpenLibraryIdentifierKey {}
+impl OpenLibraryIdentifierKey for Resource {}
 
 impl From<&str> for Resource {
     fn from(value: &str) -> Self {
@@ -50,7 +51,7 @@ impl Display for Resource {
     }
 }
 
-impl<'de> Deserialize<'de> for Identifier {
+impl<'de> Deserialize<'de> for Identifier<Resource> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -85,12 +86,12 @@ impl<'de> Deserialize<'de> for Identifier {
     }
 }
 
-impl Serialize for Identifier {
+impl Serialize for Identifier<Resource> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let string = format!("/{}/{}", self.resource, self.identifier);
+        let string = format!("/{}/{}", self.resource.to_string(), self.identifier);
         serializer.serialize_str(string.as_str())
     }
 }

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -1,4 +1,4 @@
-use crate::models::Identifier;
+use crate::models::{Identifier, Resource};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +23,7 @@ pub struct ReadingLogResponse {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ReadingLogEntry {
     pub work: ReadingLogWork,
-    pub logged_edition: Identifier,
+    pub logged_edition: Identifier<Resource>,
     #[serde(with = "crate::format")]
     pub logged_date: DateTime<Utc>,
 }
@@ -31,12 +31,12 @@ pub struct ReadingLogEntry {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ReadingLogWork {
     pub title: String,
-    pub key: Identifier,
-    pub author_keys: Vec<Identifier>,
+    pub key: Identifier<Resource>,
+    pub author_keys: Vec<Identifier<Resource>>,
     pub author_names: Vec<String>,
     pub first_publish_year: Option<i32>,
     pub lending_edition_s: Option<String>,
     pub edition_key: Vec<String>,
     pub cover_id: Option<i32>,
-    pub cover_edition_key: String,
+    pub cover_edition_key: Option<String>,
 }

--- a/src/models/books.rs
+++ b/src/models/books.rs
@@ -1,60 +1,104 @@
+use crate::models::{Identifier, OpenLibraryIdentifierKey, Resource};
 use crate::OpenLibraryError;
 use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 use url::Url;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Book {
     pub url: Url,
+    pub key: Identifier<Resource>,
     pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subtitle: Option<String>,
+    pub pagination: Option<String>,
+    pub by_statement: Option<String>,
+    pub notes: Option<String>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub authors: Vec<Entity>,
-    pub identifiers: HashMap<BookIdentifierKey, Vec<String>>,
+    #[serde(default)]
+    pub identifiers: HashMap<BookIdentifier, Vec<String>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Classifications::is_default")]
     pub classifications: Classifications,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subjects: Vec<Entity>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subject_places: Vec<Entity>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subject_people: Vec<Entity>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subject_times: Vec<Entity>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub publishers: Vec<Entity>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub publish_places: Vec<Entity>,
     pub publish_date: String,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub excerpts: Vec<Excerpt>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<String>,
-    #[serde(rename(deserialize = "cover"))]
+    #[serde(default)]
+    #[serde(rename = "covers")]
     pub cover_images: CoverImages,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ebooks: Vec<ElectronicBook>,
-    pub number_of_pages: i32,
+    pub number_of_pages: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub weight: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct BookIdentifier {
-    pub key: BookIdentifierKey,
-    pub identifier: String,
+pub enum BibliographyKey {
+    ISBN(String),
+    LCCN(String),
+    OCLC(String),
+    OLID(String),
 }
 
-impl BookIdentifier {
-    pub fn from(key: BookIdentifierKey, value: String) -> Self {
-        Self {
-            key,
-            identifier: value,
+impl BibliographyKey {
+    pub fn from((key, value): (String, String)) -> Result<Self, OpenLibraryError> {
+        match key.as_str() {
+            "ISBN" => Ok(BibliographyKey::ISBN(value)),
+            "LCCN" => Ok(BibliographyKey::LCCN(value)),
+            "OCLC" => Ok(BibliographyKey::OCLC(value)),
+            "OLID" => Ok(BibliographyKey::OLID(value)),
+            _ => Err(OpenLibraryError::ParsingError {
+                reason: format!(
+                    "Unable to determine bibliography key from specific value ({})",
+                    value
+                ),
+            }),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for BookIdentifier {
+impl Display for BibliographyKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BibliographyKey::ISBN(value) => write!(f, "ISBN:{}", value)?,
+            BibliographyKey::LCCN(value) => write!(f, "LCCN:{}", value)?,
+            BibliographyKey::OCLC(value) => write!(f, "OCLC:{}", value)?,
+            BibliographyKey::OLID(value) => write!(f, "OLID:{}", value)?,
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for BibliographyKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -67,7 +111,7 @@ impl<'de> Deserialize<'de> for BookIdentifier {
         }
 
         let key = match chunks.get(0) {
-            Some(string) => Ok(*string),
+            Some(string) => Ok(String::from(*string)),
             None => Err(D::Error::custom(format!(
                 "Supplied identifier string has improper format {}",
                 &value
@@ -75,121 +119,170 @@ impl<'de> Deserialize<'de> for BookIdentifier {
         }?;
 
         let value = match chunks.get(1) {
-            Some(string) => Ok(*string),
+            Some(string) => Ok(String::from(*string)),
             None => Err(D::Error::custom(format!(
                 "Supplied identifier string has improper format {}",
                 &value
             ))),
         }?;
 
-        let identifier = BookIdentifier {
-            key: BookIdentifierKey::try_from(key).map_err(D::Error::custom)?,
-            identifier: value.to_string(),
-        };
-
-        Ok(identifier)
+        BibliographyKey::from((key, value)).map_err(D::Error::custom)
     }
 }
 
-impl Display for BookIdentifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.key.to_string(), self.identifier)?;
-        Ok(())
+impl Serialize for BibliographyKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_str())
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum BookIdentifierKey {
-    #[serde(alias = "isbn_10")]
-    #[serde(alias = "isbn_13")]
-    ISBN, // International Standard Book Number
-    #[serde(alias = "lccn")]
-    LCCN, // Library of Congress Control Number
-    #[serde(alias = "oclc")]
-    OCLC, // Ohio College Library Center https://en.wikipedia.org/wiki/OCLC
-    #[serde(alias = "goodreads")]
-    GoodReads,
-    #[serde(alias = "openlibrary")]
-    OpenLibrary,
-    #[serde(alias = "librarything")]
-    LibraryThing, //changes necessary here
-    #[serde(alias = "project_gutenberg")]
-    ProjectGutenberg,
-}
-
-impl Display for BookIdentifierKey {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BookIdentifierKey::ISBN => write!(f, "ISBN")?,
-            BookIdentifierKey::LCCN => write!(f, "LCCN")?,
-            BookIdentifierKey::OCLC => write!(f, "OCLC")?,
-            BookIdentifierKey::GoodReads => write!(f, "GRID")?,
-            BookIdentifierKey::OpenLibrary => write!(f, "OLID")?,
-            BookIdentifierKey::LibraryThing => write!(f, "LTID")?,
-            BookIdentifierKey::ProjectGutenberg => write!(f, "PGID")?,
-        }
-        Ok(())
-    }
-}
-
-impl TryFrom<&str> for BookIdentifierKey {
-    type Error = OpenLibraryError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "ISBN" | "isbn_10" | "isbn_13" => Ok(BookIdentifierKey::ISBN),
-            "LCCN" => Ok(BookIdentifierKey::LCCN),
-            "OCLC" => Ok(BookIdentifierKey::OCLC),
-            "OLID" => Ok(BookIdentifierKey::OpenLibrary),
-            "GRID" => Ok(BookIdentifierKey::GoodReads),
-            "LTID" => Ok(BookIdentifierKey::LibraryThing),
-            "PGID" => Ok(BookIdentifierKey::ProjectGutenberg),
+impl From<Identifier<BookIdentifier>> for Result<BibliographyKey, OpenLibraryError> {
+    fn from(identifier: Identifier<BookIdentifier>) -> Self {
+        match identifier.resource {
+            BookIdentifier::InternationalStandard10 => {
+                Ok(BibliographyKey::ISBN(identifier.identifier.clone()))
+            }
+            BookIdentifier::InternationalStandard13 => {
+                Ok(BibliographyKey::ISBN(identifier.identifier.clone()))
+            }
+            BookIdentifier::LibraryOfCongress => {
+                Ok(BibliographyKey::LCCN(identifier.identifier.clone()))
+            }
+            BookIdentifier::OhioCollegeLibraryCenter => {
+                Ok(BibliographyKey::OCLC(identifier.identifier.clone()))
+            }
+            BookIdentifier::OpenLibrary => Ok(BibliographyKey::OLID(identifier.identifier.clone())),
             _ => Err(OpenLibraryError::ParsingError {
                 reason: format!(
-                    "Unable to determine Book Identifier Key from specified value {}",
-                    value
+                    "The identifier specified ({}) is not supported as a bibliogrpahy key!",
+                    identifier.resource
                 ),
             }),
         }
     }
 }
 
-#[derive(Debug, Deserialize)]
-pub struct Entity {
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum BookIdentifier {
+    #[serde(alias = "isbn_10")]
+    InternationalStandard10, // International Standard Book Number - 10 Digits
+    #[serde(alias = "isbn_13")]
+    InternationalStandard13, // International Standard Book Number - 13 Digits
+    #[serde(alias = "lccn")]
+    LibraryOfCongress, // Library of Congress Control Number
+    #[serde(alias = "oclc")]
+    OhioCollegeLibraryCenter, // Ohio College Library Center https://en.wikipedia.org/wiki/OCLC
+    #[serde(alias = "goodreads")]
+    GoodReads,
+    #[serde(alias = "openlibrary")]
+    OpenLibrary,
+    #[serde(alias = "librarything")]
+    LibraryThing,
+    #[serde(alias = "project_gutenberg")]
+    ProjectGutenberg,
+    #[serde(alias = "wikidata")]
+    WikiData,
+}
+
+impl OpenLibraryIdentifierKey for BookIdentifier {}
+
+impl Display for BookIdentifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BookIdentifier::InternationalStandard10 => Ok(write!(f, "isbn_10")?),
+            BookIdentifier::InternationalStandard13 => Ok(write!(f, "isbn_13")?),
+            BookIdentifier::LibraryOfCongress => Ok(write!(f, "lccn")?),
+            BookIdentifier::OhioCollegeLibraryCenter => Ok(write!(f, "oclc")?),
+            BookIdentifier::GoodReads => Ok(write!(f, "goodreads")?),
+            BookIdentifier::OpenLibrary => Ok(write!(f, "openlibrary")?),
+            BookIdentifier::LibraryThing => Ok(write!(f, "librarything")?),
+            BookIdentifier::ProjectGutenberg => Ok(write!(f, "project_gutenberg")?),
+            BookIdentifier::WikiData => Ok(write!(f, "wikidata")?),
+        }
+    }
+}
+
+impl FromStr for BookIdentifier {
+    type Err = OpenLibraryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "isbn_10" => Ok(BookIdentifier::InternationalStandard10),
+            "isbn_13" => Ok(BookIdentifier::InternationalStandard13),
+            "lccn" => Ok(BookIdentifier::LibraryOfCongress),
+            "oclc" => Ok(BookIdentifier::OhioCollegeLibraryCenter),
+            "goodreads" => Ok(BookIdentifier::GoodReads),
+            "openlibrary" => Ok(BookIdentifier::OpenLibrary),
+            "librarything" => Ok(BookIdentifier::LibraryThing),
+            "project_gutenberg" => Ok(BookIdentifier::ProjectGutenberg),
+            "wikidata" => Ok(BookIdentifier::WikiData),
+            _ => Err(OpenLibraryError::ParsingError {
+                reason: format!(
+                    "Unable to parse supplied value ({}) into a book identifier!",
+                    s
+                ),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Author {
+    key: Identifier<Resource>,
     name: String,
-    url: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Entity {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CoverImages {
-    small: Url,
-    medium: Url,
-    large: Url,
+    pub small: Option<Url>,
+    pub medium: Option<Url>,
+    pub large: Option<Url>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Classifications {
     #[serde(default)]
     #[serde(rename(deserialize = "dewey_decimal_class"))]
-    dewey_decimal: Vec<String>,
+    pub dewey_decimal: Vec<String>,
     #[serde(default)]
     #[serde(rename(deserialize = "lc_classifications"))]
-    library_of_congress: Vec<String>,
+    pub library_of_congress: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+impl Classifications {
+    pub fn is_default(&self) -> bool {
+        self.dewey_decimal.is_empty() && self.library_of_congress.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ElectronicBook {
     preview_url: String,
+    availability: String, //Should be enum but don't know possible values ("restricted",...)
+                          // formats: ?  //Don't know the form of the struct yet
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Excerpt {
     comment: String,
     text: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Link {
+    #[serde(skip_serializing_if = "String::is_empty")]
     url: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
     title: String,
 }

--- a/src/models/books.rs
+++ b/src/models/books.rs
@@ -143,18 +143,16 @@ impl From<Identifier<BookIdentifier>> for Result<BibliographyKey, OpenLibraryErr
     fn from(identifier: Identifier<BookIdentifier>) -> Self {
         match identifier.resource {
             BookIdentifier::InternationalStandard10 => {
-                Ok(BibliographyKey::ISBN(identifier.identifier.clone()))
+                Ok(BibliographyKey::ISBN(identifier.identifier))
             }
             BookIdentifier::InternationalStandard13 => {
-                Ok(BibliographyKey::ISBN(identifier.identifier.clone()))
+                Ok(BibliographyKey::ISBN(identifier.identifier))
             }
-            BookIdentifier::LibraryOfCongress => {
-                Ok(BibliographyKey::LCCN(identifier.identifier.clone()))
-            }
+            BookIdentifier::LibraryOfCongress => Ok(BibliographyKey::LCCN(identifier.identifier)),
             BookIdentifier::OhioCollegeLibraryCenter => {
-                Ok(BibliographyKey::OCLC(identifier.identifier.clone()))
+                Ok(BibliographyKey::OCLC(identifier.identifier))
             }
-            BookIdentifier::OpenLibrary => Ok(BibliographyKey::OLID(identifier.identifier.clone())),
+            BookIdentifier::OpenLibrary => Ok(BibliographyKey::OLID(identifier.identifier)),
             _ => Err(OpenLibraryError::ParsingError {
                 reason: format!(
                     "The identifier specified ({}) is not supported as a bibliogrpahy key!",

--- a/src/models/tests/account.rs
+++ b/src/models/tests/account.rs
@@ -3,9 +3,13 @@ use std::error::Error;
 
 #[tokio::test]
 pub async fn test_reading_log_response_serde() -> Result<(), Box<dyn Error>> {
-    let input = "{\"page\":1,\"reading_log_entries\":[{\"work\":{\"title\":\"AtomicHabits\",\"key\":\"/works/OL17930368W\",\"author_keys\":[\"/authors/OL7422948A\"],\"author_names\":[\"JamesClear\"],\"first_publish_year\":2018,\"lending_edition_s\":null,\"edition_key\":[\"OL32336498M\",\"OL27918581M\",\"OL26502528M\",\"OL31936190M\",\"OL30515574M\",\"OL30515575M\",\"OL31844060M\"],\"cover_id\":null,\"cover_edition_key\":\"OL32336498M\"},\"logged_edition\":\"/books/OL32336498M\",\"logged_date\":\"2021/09/06,00:44:47\"}]}";
+    let input = include_str!("resources/account/all-fields.json");
     let actual = serde_json::from_str::<ReadingLogResponse>(input)?;
     let output = serde_json::to_string(&actual)?;
-    assert_eq!(input, output);
+    // TODO figure out a better way to remove newlines from json instead removing all whitespace
+    assert_eq!(
+        input.split_whitespace().collect::<String>(),
+        output.split_whitespace().collect::<String>()
+    );
     Ok(())
 }

--- a/src/models/tests/books.rs
+++ b/src/models/tests/books.rs
@@ -1,36 +1,71 @@
-use crate::models::books::{BookIdentifier, BookIdentifierKey};
+use crate::models::books::{BibliographyKey, Book};
+use std::collections::HashMap;
 use std::error::Error;
 use test_case::test_case;
 
-#[test_case(BookIdentifier::from(BookIdentifierKey::ISBN, "1839485743".to_string()),
+#[test_case(BibliographyKey::ISBN("1839485743".to_string()),
             "ISBN:1839485743";
             "isbn10")]
-#[test_case(BookIdentifier::from(BookIdentifierKey::ISBN, "1839485743123".to_string()),
+#[test_case(BibliographyKey::ISBN("1839485743123".to_string()),
             "ISBN:1839485743123";
             "isbn13")]
-#[test_case(BookIdentifier::from(BookIdentifierKey::LCCN, "62019420".to_string()),
+#[test_case(BibliographyKey::LCCN("62019420".to_string()),
             "LCCN:62019420";
             "lccn")]
-#[test_case(BookIdentifier::from(BookIdentifierKey::OCLC, "ocn123456789".to_string()),
+#[test_case(BibliographyKey::OCLC("ocn123456789".to_string()),
             "OCLC:ocn123456789";
             "oclc")]
-#[test_case(BookIdentifier::from(BookIdentifierKey::OpenLibrary, "OL32770978M".to_string()),
+#[test_case(BibliographyKey::OLID("OL32770978M".to_string()),
             "OLID:OL32770978M";
             "open_library")]
-#[test_case(BookIdentifier::from(BookIdentifierKey::GoodReads, "24583".to_string()),
-            "GRID:24583";
-            "good_reads")]
 #[tokio::test]
-async fn test_book_identifier_to_string(
-    identifier: BookIdentifier,
+async fn test_bibliography_key_to_string(
+    key: BibliographyKey,
     expected: &str,
 ) -> Result<(), Box<dyn Error>> {
-    assert_eq!(identifier.to_string(), expected.to_string());
+    assert_eq!(key.to_string(), expected.to_string());
+    Ok(())
+}
+
+#[test_case("ISBN:1839485743"; "isbn10")]
+#[test_case("ISBN:1839485743123"; "isbn13")]
+#[test_case("LCCN:62019420"; "lccn")]
+#[test_case("OCLC:ocn123456789"; "oclc")]
+#[test_case("OLID:OL32770978M"; "open_library")]
+#[tokio::test]
+async fn test_bibliography_key_serde(expected: &str) -> Result<(), Box<dyn Error>> {
+    let key: BibliographyKey = serde_json::from_str(expected)?;
+    let actual = serde_json::to_string(&key)?;
+    assert_eq!(expected, actual);
     Ok(())
 }
 
 #[tokio::test]
-async fn test_book_identifier_key_serde() -> Result<(), Box<dyn Error>> {
-    assert_eq!(BookIdentifierKey::ISBN.to_string(), "ISBN");
+async fn test_serde_book_required_fields() -> Result<(), Box<dyn Error>> {
+    let expected = include_str!("resources/books/required-fields.json");
+    let book: HashMap<BibliographyKey, Book> = serde_json::from_str(expected)?;
+    let _actual = serde_json::to_string(&book)?;
+
+    // TODO need to refactor BookIdentifier before asserting equality
+    // assert_eq!(
+    //     // Terrible idea to remove all whitespace
+    //     expected.split_whitespace().collect::<String>(),
+    //     actual.split_whitespace().collect::<String>()
+    // );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_serde_book_all_fields() -> Result<(), Box<dyn Error>> {
+    let expected = include_str!("resources/books/all-fields.json");
+    let book: HashMap<BibliographyKey, Book> = serde_json::from_str(expected)?;
+    let _actual = serde_json::to_string(&book)?;
+
+    // TODO need to refactor BookIdentifier before asserting equality
+    // assert_eq!(
+    //     // Terrible idea to remove all whitespace
+    //     expected.split_whitespace().collect::<String>(),
+    //     actual.split_whitespace().collect::<String>()
+    // );
     Ok(())
 }

--- a/src/models/tests/resources/account/all-fields.json
+++ b/src/models/tests/resources/account/all-fields.json
@@ -1,0 +1,32 @@
+{
+  "page": 1,
+  "reading_log_entries": [
+    {
+      "work": {
+        "title": "Atomic Habits",
+        "key": "/works/OL17930368W",
+        "author_keys": [
+          "/authors/OL7422948A"
+        ],
+        "author_names": [
+          "James Clear"
+        ],
+        "first_publish_year": 2018,
+        "lending_edition_s": null,
+        "edition_key": [
+          "OL32336498M",
+          "OL27918581M",
+          "OL26502528M",
+          "OL31936190M",
+          "OL30515574M",
+          "OL30515575M",
+          "OL31844060M"
+        ],
+        "cover_id": null,
+        "cover_edition_key": "OL32336498M"
+      },
+      "logged_edition": "/books/OL32336498M",
+      "logged_date": "2021/09/06, 00:44:47"
+    }
+  ]
+}

--- a/src/models/tests/resources/books/all-fields.json
+++ b/src/models/tests/resources/books/all-fields.json
@@ -1,0 +1,220 @@
+{
+  "ISBN:0201558025": {
+    "url": "http://openlibrary.org/books/OL1429049M/Concrete_mathematics",
+    "key": "/books/OL1429049M",
+    "title": "Concrete mathematics",
+    "subtitle": "a foundation for computer science",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL720958A/Ronald_L._Graham",
+        "name": "Ronald L. Graham"
+      },
+      {
+        "url": "http://openlibrary.org/authors/OL229501A/Donald_Knuth",
+        "name": "Donald Knuth"
+      },
+      {
+        "url": "http://openlibrary.org/authors/OL2669938A/Oren_Patashnik",
+        "name": "Oren Patashnik"
+      }
+    ],
+    "number_of_pages": 657,
+    "pagination": "xiii, 657 p. :",
+    "by_statement": "Ronald L. Graham, Donald E. Knuth, Oren Patashnik.",
+    "identifiers": {
+      "librarything": [
+        "45844"
+      ],
+      "wikidata": [
+        "Q15303722"
+      ],
+      "goodreads": [
+        "112243"
+      ],
+      "isbn_10": [
+        "0201558025"
+      ],
+      "lccn": [
+        "93040325"
+      ],
+      "openlibrary": [
+        "OL1429049M"
+      ]
+    },
+    "classifications": {
+      "lc_classifications": [
+        "QA39.2 .G733 1994",
+        "QA39.2.G733 1994"
+      ],
+      "dewey_decimal_class": [
+        "510"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Addison-Wesley"
+      }
+    ],
+    "publish_places": [
+      {
+        "name": "Reading, Mass"
+      }
+    ],
+    "publish_date": "1994",
+    "subjects": [
+      {
+        "name": "Computer science",
+        "url": "https://openlibrary.org/subjects/computer_science"
+      },
+      {
+        "name": "Mathematics",
+        "url": "https://openlibrary.org/subjects/mathematics"
+      },
+      {
+        "name": "Computer science, mathematics",
+        "url": "https://openlibrary.org/subjects/computer_science,_mathematics"
+      }
+    ],
+    "notes": "Includes bibliographical references (p. 604-631) and index.",
+    "ebooks": [
+      {
+        "preview_url": "https://archive.org/details/concretemathemat00grah_444",
+        "availability": "restricted",
+        "formats": {}
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/135182-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/135182-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/135182-L.jpg"
+    }
+  },
+  "LCCN:93005405": {
+    "url": "http://openlibrary.org/books/OL1397864M/Zen_speaks",
+    "key": "/books/OL1397864M",
+    "title": "Zen speaks",
+    "subtitle": "shouts of nothingness",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL223368A/Zhizhong_Cai",
+        "name": "Zhizhong Cai"
+      }
+    ],
+    "number_of_pages": 159,
+    "pagination": "159 p. :",
+    "identifiers": {
+      "librarything": [
+        "192819"
+      ],
+      "goodreads": [
+        "979250"
+      ],
+      "isbn_10": [
+        "0385472579"
+      ],
+      "lccn": [
+        "93005405"
+      ],
+      "openlibrary": [
+        "OL1397864M"
+      ]
+    },
+    "classifications": {
+      "lc_classifications": [
+        "BQ9265.6 .T7313 1994"
+      ],
+      "dewey_decimal_class": [
+        "294.3/927"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Anchor Books"
+      }
+    ],
+    "publish_places": [
+      {
+        "name": "New York"
+      }
+    ],
+    "publish_date": "1994",
+    "subjects": [
+      {
+        "name": "Caricatures and cartoons",
+        "url": "https://openlibrary.org/subjects/caricatures_and_cartoons"
+      },
+      {
+        "name": "Zen Buddhism",
+        "url": "https://openlibrary.org/subjects/zen_buddhism"
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/240726-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/240726-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/240726-L.jpg"
+    }
+  },
+  "OLID:OL32336498M": {
+    "url": "http://openlibrary.org/books/OL32336498M/Atomic_Habits",
+    "key": "/books/OL32336498M",
+    "title": "Atomic Habits",
+    "authors": [
+      {
+        "url": "http://openlibrary.org/authors/OL7422948A/James_Clear",
+        "name": "James Clear"
+      }
+    ],
+    "identifiers": {
+      "isbn_13": [
+        "9780735211308"
+      ],
+      "openlibrary": [
+        "OL32336498M"
+      ]
+    },
+    "publishers": [
+      {
+        "name": "Avery"
+      }
+    ],
+    "publish_date": "2018",
+    "subjects": [
+      {
+        "name": "Habit",
+        "url": "https://openlibrary.org/subjects/habit"
+      },
+      {
+        "name": "Habit breaking",
+        "url": "https://openlibrary.org/subjects/habit_breaking"
+      },
+      {
+        "name": "Behavior modification",
+        "url": "https://openlibrary.org/subjects/behavior_modification"
+      },
+      {
+        "name": "Self-actualization (psychology)",
+        "url": "https://openlibrary.org/subjects/self-actualization_(psychology)"
+      },
+      {
+        "name": "nyt:business-books=2020-07-12",
+        "url": "https://openlibrary.org/subjects/nyt:business-books=2020-07-12"
+      },
+      {
+        "name": "New York Times bestseller",
+        "url": "https://openlibrary.org/subjects/new_york_times_bestseller"
+      }
+    ],
+    "ebooks": [
+      {
+        "preview_url": "https://archive.org/details/atomic-habits-tiny-changes-remarkable-results-by-james-clear-z-lib.org",
+        "availability": "restricted",
+        "formats": {}
+      }
+    ],
+    "cover": {
+      "small": "https://covers.openlibrary.org/b/id/10958382-S.jpg",
+      "medium": "https://covers.openlibrary.org/b/id/10958382-M.jpg",
+      "large": "https://covers.openlibrary.org/b/id/10958382-L.jpg"
+    }
+  }
+}

--- a/src/models/tests/resources/books/required-fields.json
+++ b/src/models/tests/resources/books/required-fields.json
@@ -1,0 +1,20 @@
+{
+  "ISBN:0201558025": {
+    "url": "http://openlibrary.org/books/OL1429049M/Concrete_mathematics",
+    "key": "/books/OL1429049M",
+    "title": "Concrete mathematics",
+    "publish_date": "1994"
+  },
+  "LCCN:93005405": {
+    "url": "http://openlibrary.org/books/OL1397864M/Zen_speaks",
+    "key": "/books/OL1397864M",
+    "title": "Zen speaks",
+    "publish_date": "1994"
+  },
+  "OLID:OL32336498M": {
+    "url": "http://openlibrary.org/books/OL32336498M/Atomic_Habits",
+    "key": "/books/OL32336498M",
+    "title": "Atomic Habits",
+    "publish_date": "2018"
+  }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 extern crate open_library;
+use open_library::models::books::BibliographyKey;
 use open_library::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
 use std::error::Error;
-use open_library::models::books::BibliographyKey;
 
 #[tokio::test]
 async fn verify_identifier_values() -> Result<(), Box<dyn Error>> {
@@ -20,8 +20,16 @@ async fn verify_identifier_values() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn verify_authed_endpoint() -> Result<(), Box<dyn Error>> {
     let auth_client = OpenLibraryAuthClient::new()?;
-    let username = std::env::var("OPEN_LIBRARY_USERNAME")?;
-    let password = std::env::var("OPEN_LIBRARY_PASSWORD")?;
+    let username = std::env::var("OPEN_LIBRARY_USERNAME").map_err(|_e| {
+        OpenLibraryError::NotAuthenticated {
+            reason: "Unable to find username in environment variables!".to_string(),
+        }
+    })?;
+    let password = std::env::var("OPEN_LIBRARY_PASSWORD").map_err(|_e| {
+        OpenLibraryError::NotAuthenticated {
+            reason: "Unable to find password in environment variables!".to_string(),
+        }
+    })?;
     let session = auth_client.login(username, password).await?;
     let _client = OpenLibraryClient::builder().with_session(session).build()?;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,12 @@
 extern crate open_library;
-use open_library::models::books::{BookIdentifier, BookIdentifierKey};
-use open_library::{OpenLibraryAuthClient, OpenLibraryClient};
+use open_library::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
 use std::error::Error;
+use open_library::models::books::BibliographyKey;
 
 #[tokio::test]
 async fn verify_identifier_values() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
-    let identifier = BookIdentifier::from(BookIdentifierKey::ISBN, "0374386137".to_string());
+    let identifier = BibliographyKey::ISBN("0374386137".to_string());
     let book_results = client.books.search(vec![&identifier]).await?;
     let book = book_results
         .get(&identifier)
@@ -31,8 +31,16 @@ async fn verify_authed_endpoint() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn verify_want_to_read() -> Result<(), Box<dyn Error>> {
     let auth_client = OpenLibraryAuthClient::new()?;
-    let username = std::env::var("OPEN_LIBRARY_USERNAME")?;
-    let password = std::env::var("OPEN_LIBRARY_PASSWORD")?;
+    let username = std::env::var("OPEN_LIBRARY_USERNAME").map_err(|_e| {
+        OpenLibraryError::NotAuthenticated {
+            reason: "Unable to find username in environment variables!".to_string(),
+        }
+    })?;
+    let password = std::env::var("OPEN_LIBRARY_PASSWORD").map_err(|_e| {
+        OpenLibraryError::NotAuthenticated {
+            reason: "Unable to find password in environment variables!".to_string(),
+        }
+    })?;
     let session = auth_client
         .login(username.clone(), password.clone())
         .await?;


### PR DESCRIPTION
## Description

After starting with the Book Search endpoint, it was assumed that the identifiers would all follow a similar format of `{TYPE}:{VALUE}`. Example: `ISBN:1294393402`. 

Most identifiers from OpenLibrary are of the form `/works/OL289349`, `/author/OL39842` so this pull request takes care of making the previous identifiers unique to the Book Search endpoint via `BibliographyKey` and makes the existing `Identifier` class more generic to be able to use more widely. 

### Wiremock

Started the use of Wiremock to have consistent mocked payloads returned from the APIs. This will reduce the burden of actually hitting the OpenLibrary APIs for testing (reduced to only integration testing). 

### Issues 
Closes #19 
Related to #20 