### PR TITLE
Handling Multiple Reading Log Responses

### DIFF
--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -53,7 +53,10 @@ impl BooksClient {
                 .json::<HashMap<BibliographyKey, Book>>()
                 .await
                 .map_err(|error| OpenLibraryError::JsonParseError { source: error })?),
-            _ => Err(OpenLibraryError::ApiError { response }),
+            _ => Err(OpenLibraryError::ApiError {
+                status_code: response.status(),
+                error: None,
+            }),
         }?;
 
         Ok(results)

--- a/src/clients/tests/account.rs
+++ b/src/clients/tests/account.rs
@@ -1,5 +1,5 @@
 use crate::models::account::{LoginRequest, ReadingLogResponse, Session};
-use crate::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
+use crate::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError, OpenLibraryErrorResponse};
 use http::Method;
 use std::error::Error;
 use url::Url;
@@ -58,7 +58,10 @@ async fn test_login_returns_error_on_failure() -> Result<(), Box<dyn Error>> {
     let error = actual.expect_err("Expected login to return an error!");
 
     match error {
-        OpenLibraryError::ApiError { response: _ } => Ok(()),
+        OpenLibraryError::ApiError {
+            status_code: _,
+            error: _,
+        } => Ok(()),
         _ => panic!(
             "Expected to receive an Api Error but received {:?} instead!",
             &error
@@ -97,4 +100,47 @@ async fn test_want_to_read_returns_success() -> Result<(), Box<dyn Error>> {
 
     assert_eq!(actual.len(), 1);
     Ok(())
+}
+
+#[tokio::test]
+async fn test_want_to_read_returns_failure_when_error_is_returned() -> Result<(), Box<dyn Error>> {
+    let server = MockServer::start().await;
+
+    let mock_session = Session::from("mock_session_cookie".to_string(), "mock_user".to_string());
+
+    let client = OpenLibraryClient::builder()
+        .with_session(&mock_session)
+        .with_host(Url::parse(server.uri().as_str())?)
+        .build()?;
+
+    Mock::given(method(Method::GET.as_str()))
+        .and(path("/people/mock_user/books/want-to-read.json"))
+        .and(header(
+            http::header::COOKIE.as_str(),
+            mock_session.cookie().as_str(),
+        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(OpenLibraryErrorResponse {
+                error: "Shelf want-to-read not found or not accessible".to_string(),
+            }),
+        )
+        .mount(&server)
+        .await;
+
+    let actual = client
+        .account
+        .get_want_to_read("mock_user".to_string())
+        .await;
+
+    let error = actual.err().unwrap();
+    match error {
+        OpenLibraryError::ApiError {
+            status_code: _,
+            error: _,
+        } => Ok(()),
+        _ => panic!(
+            "Expected call to return a Api Error but returned {:?} instead",
+            error
+        ),
+    }
 }

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -65,7 +65,10 @@ async fn test_book_search_returns_failure_when_request_fails() -> Result<(), Box
     let actual = client.books.search(identifiers).await;
     let error = actual.expect_err("Expected Book Search call to return an error but it didn't!");
     match &error {
-        OpenLibraryError::ApiError { response: _ } => Ok(()),
+        OpenLibraryError::ApiError {
+            status_code: _,
+            error: _,
+        } => Ok(()),
         _ => panic!(
             "Expected to received an API error, but received {:?} instead!",
             error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ use crate::clients::account::AccountClient;
 use crate::models::account::Session;
 use clients::books::BooksClient;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{ClientBuilder, Response};
+use reqwest::{ClientBuilder, StatusCode};
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
 use url::Url;
@@ -15,8 +16,15 @@ mod tests;
 
 #[derive(Debug, Error)]
 pub enum OpenLibraryError {
-    #[error("Received an error response from the Open Library API: {:?}", response)]
-    ApiError { response: Response },
+    #[error(
+        "Received an {:?} response from the Open Library API: {:?}",
+        status_code,
+        error
+    )]
+    ApiError {
+        status_code: StatusCode,
+        error: Option<OpenLibraryErrorResponse>,
+    },
     #[error("Unable to build HTTP client: {}", source)]
     ClientBuildingError { source: reqwest::Error },
     #[error("An internal error occurred: {}", reason)]
@@ -29,6 +37,11 @@ pub enum OpenLibraryError {
     ParsingError { reason: String },
     #[error("An error occurred while sending HTTP request: {}", source)]
     RequestFailed { source: reqwest::Error },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OpenLibraryErrorResponse {
+    pub error: String,
 }
 
 pub struct OpenLibraryAuthClient {


### PR DESCRIPTION
## Description

The Reading Log endpoints always return 200, even when the user doesn't exist or there are no permissions to currently view it. 

### Multiple Bodies

Leveraging the `ReadingLogResponseWrapper` as a type to enumerate the possible response bodies from `GET want-to-read.json`. 

### Issues 
Closes #23 