### PR TITLE
Patching Crate Name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "open_library"
+name = "open-library"
 description = "A client to interact with the Open Library API"
 version = "0.2.1-alpha.0"
 authors = ["Brett Spradling <brett@spradling.me>"]

--- a/examples/book-cli/Cargo.toml
+++ b/examples/book-cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "book-cli"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+open-library = "0.1.0"

--- a/examples/book-cli/src/main.rs
+++ b/examples/book-cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,3 @@
-extern crate open_library;
 use open_library::models::books::BibliographyKey;
 use open_library::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
 use std::error::Error;


### PR DESCRIPTION
## Description

Ensuring the package name is consistent with crates.io. 

### Example Project

Starting an example project in order to show working examples of `open-library` and ensure it's consumable from crates.io

### Issues
Begins #10 