### PR TITLE
Editions API Implementation

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -13,15 +13,11 @@ pub mod works;
 #[cfg(test)]
 mod tests;
 
-pub async fn get<T>(client: Client, url: Url) -> Result<T, OpenLibraryError>
+pub async fn get<T>(client: &Client, url: Url) -> Result<T, OpenLibraryError>
 where
     T: for<'de> Deserialize<'de> + OpenLibraryModel,
 {
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
+    let response = client.get(url).send().await?;
 
     return match response.status() {
         StatusCode::OK => Ok(response

--- a/src/clients/account.rs
+++ b/src/clients/account.rs
@@ -34,8 +34,7 @@ impl AccountClient {
                 password: password.clone(),
             })
             .send()
-            .await
-            .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
+            .await?;
 
         match response.status() {
             StatusCode::OK => {
@@ -105,12 +104,7 @@ impl AccountClient {
     }
 
     async fn get_reading_log(&self, url: Url) -> Result<Vec<ReadingLogEntry>, OpenLibraryError> {
-        let response = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
+        let response = self.client.get(url).send().await?;
 
         let status_code = response.status();
         let reading_log_response = response

--- a/src/clients/author.rs
+++ b/src/clients/author.rs
@@ -22,15 +22,10 @@ impl AuthorClient {
     pub async fn search(&self, author_name: &str) -> Result<AuthorResponse, OpenLibraryError> {
         let response = self
             .client
-            .get(self.host.join("search/authors.json").map_err(|_e| {
-                OpenLibraryError::ParsingError {
-                    reason: "Unable to parse into valid URL".to_string(),
-                }
-            })?)
+            .get(self.host.join("search/authors.json")?)
             .query(&[(QueryParameters::AuthorQuery, author_name)])
             .send()
-            .await
-            .map_err(|error| OpenLibraryError::RequestFailed { source: error })?;
+            .await?;
 
         let results: AuthorResponse = match response.status() {
             StatusCode::OK => Ok(response

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+mod get;
 mod isbn;
 
 #[tokio::test]

--- a/src/clients/tests/books/get.rs
+++ b/src/clients/tests/books/get.rs
@@ -1,0 +1,30 @@
+use crate::models::books::Book;
+use crate::models::identifiers::{Identifier, OpenLibraryIdentifer};
+use crate::OpenLibraryClient;
+use http::Method;
+use reqwest::Url;
+use std::error::Error;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_get_returns_success() -> Result<(), Box<dyn Error>> {
+    let server = MockServer::start().await;
+    let client = OpenLibraryClient::builder()
+        .with_host(Url::parse(server.uri().as_str())?)
+        .build()?;
+
+    let mock_response: Book = serde_json::from_str(include_str!("resources/edition.json"))?;
+
+    let olid = OpenLibraryIdentifer::from("OL7353617M")?;
+
+    Mock::given(method(Method::GET.as_str()))
+        .and(path(format!("/books/{}.json", olid.value()).as_str()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&mock_response))
+        .mount(&server)
+        .await;
+
+    let actual = client.books.get(olid).await?;
+    assert_eq!(actual, mock_response);
+    Ok(())
+}

--- a/src/clients/tests/books/resources/edition.json
+++ b/src/clients/tests/books/resources/edition.json
@@ -1,0 +1,45 @@
+{
+  "publishers": ["Puffin"],
+  "number_of_pages": 96,
+  "isbn_10": ["0140328726"],
+  "covers": [8739161],
+  "key": "/books/OL7353617M",
+  "authors": [{
+    "key": "/authors/OL34184A"
+  }],
+  "ocaid": "fantasticmrfoxpu00roal",
+  "contributions": ["Tony Ross (Illustrator)"],
+  "languages": [{
+    "key": "/languages/eng"
+  }],
+  "classifications": {},
+  "source_records": ["ia:fantasticmrfox00dahl_834", "marc:marc_openlibraries_sanfranciscopubliclibrary/sfpl_chq_2018_12_24_run02.mrc:85081404:4525"],
+  "title": "Fantastic Mr. Fox",
+  "identifiers": {
+    "goodreads": ["1507552"],
+    "librarything": ["6446"]
+  },
+  "isbn_13": ["9780140328721"],
+  "local_id": ["urn:sfpl:31223064402481", "urn:sfpl:31223117624784", "urn:sfpl:31223113969183", "urn:sfpl:31223117624800", "urn:sfpl:31223113969225", "urn:sfpl:31223106484539", "urn:sfpl:31223117624792", "urn:sfpl:31223117624818", "urn:sfpl:31223117624768", "urn:sfpl:31223117624743", "urn:sfpl:31223113969209", "urn:sfpl:31223117624750", "urn:sfpl:31223117624727", "urn:sfpl:31223117624776", "urn:sfpl:31223117624719", "urn:sfpl:31223117624735", "urn:sfpl:31223113969241"],
+  "publish_date": "October 1, 1988",
+  "works": [{
+    "key": "/works/OL45883W"
+  }],
+  "type": {
+    "key": "/type/edition"
+  },
+  "first_sentence": {
+    "type": "/type/text",
+    "value": "And these two very old people are the father and mother of Mrs. Bucket."
+  },
+  "latest_revision": 14,
+  "revision": 14,
+  "created": {
+    "type": "/type/datetime",
+    "value": "2008-04-29T13:35:46.876380"
+  },
+  "last_modified": {
+    "type": "/type/datetime",
+    "value": "2021-06-18T22:46:46.648233"
+  }
+}

--- a/src/clients/works.rs
+++ b/src/clients/works.rs
@@ -19,17 +19,10 @@ impl WorksClient {
     }
 
     pub async fn get(&self, identifier: &OpenLibraryIdentifer) -> Result<Work, OpenLibraryError> {
-        let path = format!("/works/{}.json", identifier.value());
-        let url =
-            self.host
-                .join(path.as_str())
-                .map_err(|error| OpenLibraryError::ParsingError {
-                    reason: format!(
-                        "Invalid URL from base url ({}) and path ({}): {}",
-                        self.host, path, error
-                    ),
-                })?;
+        let url = self
+            .host
+            .join(format!("/works/{}.json", identifier.value()).as_str())?;
 
-        get(self.client.clone(), url).await
+        get(&self.client, url).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@ use crate::clients::works::WorksClient;
 use crate::models::account::Session;
 use clients::books::BooksClient;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{ClientBuilder, StatusCode};
+use reqwest::{ClientBuilder, Error, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
-use url::Url;
+use url::{ParseError, Url};
 
 mod clients;
 mod format;
@@ -39,6 +39,20 @@ pub enum OpenLibraryError {
     ParsingError { reason: String },
     #[error("An error occurred while sending HTTP request: {}", source)]
     RequestFailed { source: reqwest::Error },
+}
+
+impl From<reqwest::Error> for OpenLibraryError {
+    fn from(error: Error) -> Self {
+        OpenLibraryError::RequestFailed { source: error }
+    }
+}
+
+impl From<ParseError> for OpenLibraryError {
+    fn from(error: ParseError) -> Self {
+        OpenLibraryError::ParsingError {
+            reason: error.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/tests/clients.rs
+++ b/src/tests/clients.rs
@@ -31,7 +31,7 @@ pub async fn test_get_returns_successfully() -> Result<(), Box<dyn Error>> {
         .mount(&server)
         .await;
 
-    let actual: FakeResponse = get(Client::new(), base_url.join(url_path)?).await?;
+    let actual: FakeResponse = get(&Client::new(), base_url.join(url_path)?).await?;
 
     assert_eq!(actual, expected);
     Ok(())
@@ -49,7 +49,7 @@ pub async fn test_get_returns_error_when_receives_invalid_json() -> Result<(), B
         .mount(&server)
         .await;
 
-    let response = get::<FakeResponse>(Client::new(), base_url.join(url_path)?).await;
+    let response = get::<FakeResponse>(&Client::new(), base_url.join(url_path)?).await;
     let actual =
         response.expect_err("Expected call to return error but it completed successfully!");
 
@@ -71,7 +71,7 @@ pub async fn test_get_returns_error_when_api_responds_with_error() -> Result<(),
         .mount(&server)
         .await;
 
-    let response = get::<FakeResponse>(Client::new(), base_url.join(url_path)?).await;
+    let response = get::<FakeResponse>(&Client::new(), base_url.join(url_path)?).await;
     let actual =
         response.expect_err("Expected call to return error but it completed successfully!");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,28 @@ use open_library::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
 use std::error::Error;
 
 #[tokio::test]
+async fn test_book_by_isbn() -> Result<(), Box<dyn Error>> {
+    let client = OpenLibraryClient::builder().build()?;
+    let isbn = InternationalStandardBookNumber::from("0374386137")?;
+    let book = client.books.by_isbn(isbn).await?;
+
+    assert_eq!(book.title, "A Wrinkle in Time");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_book_get() -> Result<(), Box<dyn Error>> {
+    let client = OpenLibraryClient::builder().build()?;
+    let olid = OpenLibraryIdentifer::from("OL8458764M")?;
+    let book = client.books.get(olid).await?;
+
+    assert_eq!(book.title, "Hatchet");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_book_search() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
     let identifier = BibliographyKey::ISBN("0374386137".to_string());
@@ -12,17 +34,6 @@ async fn test_book_search() -> Result<(), Box<dyn Error>> {
     let book = book_results
         .get(&identifier)
         .ok_or(format!("No book found with identifier {}", identifier))?;
-
-    assert_eq!(book.title, "A Wrinkle in Time");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_book_by_isbn() -> Result<(), Box<dyn Error>> {
-    let client = OpenLibraryClient::builder().build()?;
-    let isbn = InternationalStandardBookNumber::from("0374386137")?;
-    let book = client.books.by_isbn(isbn).await?;
 
     assert_eq!(book.title, "A Wrinkle in Time");
 


### PR DESCRIPTION
## Description

Adding the ability to retrieve a Book Edition via **GET** `/books/{}.json`

## Implementation Notes

### Simplified Error Handling 
Leveraging  `From` trait to simplify a lot of boilerplate code around covering extraneous errors into `OpenLibraryError`

## Issues
Resolves #8 