### PR TITLE
Refactoring Identifiers

### DIFF
--- a/examples/book-cli/src/main.rs
+++ b/examples/book-cli/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     let client = OpenLibraryClient::builder().build()?;
 
     let isbn = arguments.isbn().into_iter().map(|id| Identifier {
-        resource: BookIdentifier::isbn_from(&id).unwrap(),
+        resource: BookIdentifier::from_isbn(&id).unwrap(),
         identifier: id,
     });
     let oclc = arguments.oclc().into_iter().map(|id| Identifier {

--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -55,21 +55,23 @@ impl BooksClient {
         get(&self.client, url).await
     }
 
-    pub async fn search(
+    pub async fn search<T>(
         &self,
-        identifiers: &[BibliographyKey],
-    ) -> Result<HashMap<BibliographyKey, Book>, OpenLibraryError> {
-        // tracing::info!("Identifiers: {:?}", identifiers);
+        identifiers: T,
+    ) -> Result<HashMap<BibliographyKey, Book>, OpenLibraryError>
+    where
+        T: Into<Vec<BibliographyKey>>,
+    {
         let ids_filter = identifiers
+            .into()
             .iter()
             .map(|id| id.to_string())
             .collect::<Vec<String>>()
             .join(",");
 
-        let path = "/api/books";
         let response = self
             .client
-            .get(self.host.join(path)?)
+            .get(self.host.join("/api/books")?)
             .query(&[
                 (QueryParameters::BibliographyKeys, &ids_filter),
                 (QueryParameters::Format, &String::from("json")),

--- a/src/clients/tests/books.rs
+++ b/src/clients/tests/books.rs
@@ -36,7 +36,7 @@ async fn test_book_search_returns_success() -> Result<(), Box<dyn Error>> {
         .mount(&server)
         .await;
 
-    let actual = client.books.search(&identifiers).await?;
+    let actual = client.books.search(identifiers).await?;
 
     assert_eq!(actual.keys().len(), 3);
     Ok(())
@@ -65,7 +65,7 @@ async fn test_book_search_returns_failure_when_request_fails() -> Result<(), Box
         .mount(&server)
         .await;
 
-    let actual = client.books.search(&identifiers).await;
+    let actual = client.books.search(identifiers).await;
     let error = actual.expect_err("Expected Book Search call to return an error but it didn't!");
     match &error {
         OpenLibraryError::ApiError {

--- a/src/clients/tests/books/get.rs
+++ b/src/clients/tests/books/get.rs
@@ -4,6 +4,7 @@ use crate::OpenLibraryClient;
 use http::Method;
 use reqwest::Url;
 use std::error::Error;
+use std::str::FromStr;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -16,7 +17,7 @@ async fn test_get_returns_success() -> Result<(), Box<dyn Error>> {
 
     let mock_response: Book = serde_json::from_str(include_str!("resources/edition.json"))?;
 
-    let olid = OpenLibraryIdentifer::from("OL7353617M")?;
+    let olid = OpenLibraryIdentifer::from_str("OL7353617M")?;
 
     Mock::given(method(Method::GET.as_str()))
         .and(path(format!("/books/{}.json", olid.value()).as_str()))

--- a/src/clients/tests/books/isbn.rs
+++ b/src/clients/tests/books/isbn.rs
@@ -4,6 +4,7 @@ use crate::{OpenLibraryClient, OpenLibraryError};
 use http::Method;
 use reqwest::Url;
 use std::error::Error;
+use std::str::FromStr;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -16,7 +17,7 @@ async fn test_get_isbn_returns_success() -> Result<(), Box<dyn Error>> {
 
     let mock_response: Book = serde_json::from_str(include_str!("resources/isbn.json"))?;
 
-    let isbn = InternationalStandardBookNumber::from("0201558025")?;
+    let isbn = InternationalStandardBookNumber::from_str("0201558025")?;
 
     Mock::given(method(Method::GET.as_str()))
         .and(path(format!("/isbn/{}.json", isbn.value()).as_str()))
@@ -36,7 +37,7 @@ async fn test_get_isbn_returns_error_when_invalid_json_returned() -> Result<(), 
         .with_host(Url::parse(server.uri().as_str())?)
         .build()?;
 
-    let isbn = InternationalStandardBookNumber::from("0201558025")?;
+    let isbn = InternationalStandardBookNumber::from_str("0201558025")?;
 
     Mock::given(method(Method::GET.as_str()))
         .and(path(format!("/isbn/{}.json", isbn.value()).as_str()))
@@ -64,7 +65,7 @@ async fn test_get_isbn_returns_error_when_book_does_not_exist() -> Result<(), Bo
         .with_host(Url::parse(server.uri().as_str())?)
         .build()?;
 
-    let isbn = InternationalStandardBookNumber::from("_doesnotexist")?;
+    let isbn = InternationalStandardBookNumber::from_str("_doesnotexist")?;
 
     Mock::given(method(Method::GET.as_str()))
         .and(path(format!("/isbn/{}.json", isbn.value()).as_str()))

--- a/src/clients/tests/works.rs
+++ b/src/clients/tests/works.rs
@@ -3,6 +3,7 @@ use crate::models::works::Work;
 use crate::OpenLibraryClient;
 use reqwest::{Method, Url};
 use std::error::Error;
+use std::str::FromStr;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -13,7 +14,7 @@ async fn test_works_get_returns_success() -> Result<(), Box<dyn Error>> {
         .with_host(Url::parse(server.uri().as_str())?)
         .build()?;
 
-    let mock_work_identifier = OpenLibraryIdentifer::from("OL92304270")?;
+    let mock_work_identifier = OpenLibraryIdentifer::from_str("OL92304270")?;
     let mock_response: Work = serde_json::from_str(include_str!("resources/work.json"))?;
 
     Mock::given(method(Method::GET.as_str()))

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -1,4 +1,4 @@
-use crate::models::{Identifier, Resource};
+use crate::models::Resource;
 use crate::{OpenLibraryClient, OpenLibraryError, OpenLibraryErrorResponse};
 use chrono::{DateTime, Utc};
 use serde::de::Error;
@@ -91,7 +91,7 @@ pub struct ReadingLogResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ReadingLogEntry {
     pub work: ReadingLogWork,
-    pub logged_edition: Identifier<Resource>,
+    pub logged_edition: Resource,
     #[serde(with = "crate::format::datetime")]
     pub logged_date: DateTime<Utc>,
 }
@@ -99,8 +99,8 @@ pub struct ReadingLogEntry {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ReadingLogWork {
     pub title: String,
-    pub key: Identifier<Resource>,
-    pub author_keys: Vec<Identifier<Resource>>,
+    pub key: Resource,
+    pub author_keys: Vec<Resource>,
     pub author_names: Vec<String>,
     pub first_publish_year: Option<i32>,
     pub lending_edition_s: Option<String>,

--- a/src/models/works.rs
+++ b/src/models/works.rs
@@ -1,6 +1,6 @@
-use crate::models::books::{Author, BookIdentifier, Classifications};
+use crate::models::books::{Author, BookIdentifierKey, Classifications};
 use crate::models::identifiers::InternationalStandardBookNumber;
-use crate::models::{Identifier, OpenLibraryModel, Resource};
+use crate::models::{OpenLibraryModel, Resource};
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -14,7 +14,7 @@ pub struct Work {
     #[serde(rename = "isbn_10")]
     pub isbns_10: Vec<InternationalStandardBookNumber>,
     pub covers: Vec<u32>, //TODO Cover Id
-    pub key: Identifier<Resource>,
+    pub key: Resource,
     pub authors: Vec<Author>,
     pub ocaid: String,
     pub contributions: Vec<String>,
@@ -24,14 +24,14 @@ pub struct Work {
     pub source_records: Vec<String>, //TODO Parse these?
     pub title: String,
     #[serde(default)]
-    pub identifiers: HashMap<BookIdentifier, Vec<String>>,
+    pub identifiers: HashMap<BookIdentifierKey, Vec<String>>,
     #[serde(rename = "isbn_13")]
     pub isbns_13: Vec<InternationalStandardBookNumber>,
     pub local_id: Vec<String>, //TODO Parse?
     #[serde(with = "crate::format::date_m_dd_yyyy")]
     pub publish_date: NaiveDate,
     #[serde(with = "crate::format::keyed_list")]
-    pub works: Vec<Identifier<Resource>>,
+    pub works: Vec<Resource>,
     #[serde(rename = "type")]
     #[serde(with = "crate::format::keyed_value")]
     pub works_type: String,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,11 +2,12 @@ use open_library::models::books::BibliographyKey;
 use open_library::models::identifiers::{InternationalStandardBookNumber, OpenLibraryIdentifer};
 use open_library::{OpenLibraryAuthClient, OpenLibraryClient, OpenLibraryError};
 use std::error::Error;
+use std::str::FromStr;
 
 #[tokio::test]
 async fn test_book_by_isbn() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
-    let isbn = InternationalStandardBookNumber::from("0374386137")?;
+    let isbn = InternationalStandardBookNumber::from_str("0374386137")?;
     let book = client.books.by_isbn(isbn).await?;
 
     assert_eq!(book.title, "A Wrinkle in Time");
@@ -17,7 +18,7 @@ async fn test_book_by_isbn() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn test_book_get() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
-    let olid = OpenLibraryIdentifer::from("OL8458764M")?;
+    let olid = OpenLibraryIdentifer::from_str("OL8458764M")?;
     let book = client.books.get(olid).await?;
 
     assert_eq!(book.title, "Hatchet");
@@ -30,7 +31,7 @@ async fn test_book_search() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
     let identifier = BibliographyKey::ISBN("0374386137".to_string());
     let identifiers = vec![identifier.clone()];
-    let book_results = client.books.search(&identifiers).await?;
+    let book_results = client.books.search(identifiers).await?;
     let book = book_results
         .get(&identifier)
         .ok_or(format!("No book found with identifier {}", identifier))?;
@@ -43,7 +44,7 @@ async fn test_book_search() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn test_works_get() -> Result<(), Box<dyn Error>> {
     let client = OpenLibraryClient::builder().build()?;
-    let works_id = OpenLibraryIdentifer::from("OL7353617M")?;
+    let works_id = OpenLibraryIdentifer::from_str("OL7353617M")?;
     let work = client.works.get(&works_id).await?;
 
     assert_eq!(work.title, "Fantastic Mr. Fox");


### PR DESCRIPTION
## Description

Making the identifiers more consistent and reduce code duplication.

## Implementation Notes

### OpenLibrary Identifiers 

Introduced a `identifier!` macro to easily create another resource identifier for an Open Library Model

**Example**: `identifier!(InternationalStandardBookNumber, "ISBN");`

### Resource Identifiers 

Reduced the Resource identifiers to an Enum instead of a Struct which was not necessary.

## Issues
Addresses #35 
