### PR TITLE
Consolidating Handling API Responses

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -1,9 +1,8 @@
 use crate::models::OpenLibraryModel;
 use crate::OpenLibraryError;
 use http::StatusCode;
-use reqwest::Client;
+use reqwest::RequestBuilder;
 use serde::Deserialize;
-use url::Url;
 
 pub mod account;
 pub mod author;
@@ -13,11 +12,11 @@ pub mod works;
 #[cfg(test)]
 mod tests;
 
-pub async fn get<T>(client: &Client, url: Url) -> Result<T, OpenLibraryError>
+pub async fn handle<T>(request: RequestBuilder) -> Result<T, OpenLibraryError>
 where
     T: for<'de> Deserialize<'de> + OpenLibraryModel,
 {
-    let response = client.get(url).send().await?;
+    let response = request.send().await?;
 
     return match response.status() {
         StatusCode::OK => Ok(response

--- a/src/clients/author.rs
+++ b/src/clients/author.rs
@@ -1,6 +1,6 @@
+use crate::clients::handle;
 use crate::models::authors::AuthorResponse;
 use crate::OpenLibraryError;
-use http::StatusCode;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -20,25 +20,12 @@ impl AuthorClient {
     }
 
     pub async fn search(&self, author_name: &str) -> Result<AuthorResponse, OpenLibraryError> {
-        let response = self
-            .client
-            .get(self.host.join("search/authors.json")?)
-            .query(&[(QueryParameters::AuthorQuery, author_name)])
-            .send()
-            .await?;
-
-        let results: AuthorResponse = match response.status() {
-            StatusCode::OK => Ok(response
-                .json::<AuthorResponse>()
-                .await
-                .map_err(|error| OpenLibraryError::JsonParseError { source: error })?),
-            _ => Err(OpenLibraryError::ApiError {
-                status_code: response.status(),
-                error: None,
-            }),
-        }?;
-
-        Ok(results)
+        handle(
+            self.client
+                .get(self.host.join("search/authors.json")?)
+                .query(&[(QueryParameters::AuthorQuery, author_name)]),
+        )
+        .await
     }
 }
 

--- a/src/clients/books.rs
+++ b/src/clients/books.rs
@@ -1,10 +1,10 @@
-use crate::clients::get;
+use crate::clients::handle;
 use crate::models::books::{BibliographyKey, Book};
 use crate::models::identifiers::{
     Identifier, InternationalStandardBookNumber, OpenLibraryIdentifer,
 };
+use crate::models::OpenLibraryModel;
 use crate::OpenLibraryError;
-use http::StatusCode;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -15,6 +15,9 @@ pub struct BooksClient {
     client: Client,
     host: Url,
 }
+
+type BookSearchResponse = HashMap<BibliographyKey, Book>;
+impl OpenLibraryModel for BookSearchResponse {}
 
 impl BooksClient {
     pub fn new(client: &Client, host: &Url) -> Self {
@@ -28,23 +31,11 @@ impl BooksClient {
         &self,
         isbn: InternationalStandardBookNumber,
     ) -> Result<Book, OpenLibraryError> {
-        let path = format!("/isbn/{}.json", isbn.value());
-        let response = self
-            .client
-            .get(self.host.join(path.as_str())?)
-            .send()
-            .await?;
+        let url = self
+            .host
+            .join(format!("/isbn/{}.json", isbn.value()).as_str())?;
 
-        return match response.status() {
-            StatusCode::OK => Ok(response
-                .json::<Book>()
-                .await
-                .map_err(|error| OpenLibraryError::JsonParseError { source: error })?),
-            _ => Err(OpenLibraryError::ApiError {
-                status_code: response.status(),
-                error: None,
-            }),
-        };
+        handle(self.client.get(url)).await
     }
 
     pub async fn get(&self, identifier: OpenLibraryIdentifer) -> Result<Book, OpenLibraryError> {
@@ -52,13 +43,10 @@ impl BooksClient {
             .host
             .join(format!("/books/{}.json", identifier.value()).as_str())?;
 
-        get(&self.client, url).await
+        handle(self.client.get(url)).await
     }
 
-    pub async fn search<T>(
-        &self,
-        identifiers: T,
-    ) -> Result<HashMap<BibliographyKey, Book>, OpenLibraryError>
+    pub async fn search<T>(&self, identifiers: T) -> Result<BookSearchResponse, OpenLibraryError>
     where
         T: Into<Vec<BibliographyKey>>,
     {
@@ -69,29 +57,12 @@ impl BooksClient {
             .collect::<Vec<String>>()
             .join(",");
 
-        let response = self
-            .client
-            .get(self.host.join("/api/books")?)
-            .query(&[
-                (QueryParameters::BibliographyKeys, &ids_filter),
-                (QueryParameters::Format, &String::from("json")),
-                (QueryParameters::JavascriptCommand, &String::from("data")),
-            ])
-            .send()
-            .await?;
-
-        let results: HashMap<BibliographyKey, Book> = match response.status() {
-            StatusCode::OK => Ok(response
-                .json::<HashMap<BibliographyKey, Book>>()
-                .await
-                .map_err(|error| OpenLibraryError::JsonParseError { source: error })?),
-            _ => Err(OpenLibraryError::ApiError {
-                status_code: response.status(),
-                error: None,
-            }),
-        }?;
-
-        Ok(results)
+        handle(self.client.get(self.host.join("/api/books")?).query(&[
+            (QueryParameters::BibliographyKeys, &ids_filter),
+            (QueryParameters::Format, &String::from("json")),
+            (QueryParameters::JavascriptCommand, &String::from("data")),
+        ]))
+        .await
     }
 }
 

--- a/src/clients/works.rs
+++ b/src/clients/works.rs
@@ -1,4 +1,4 @@
-use crate::clients::get;
+use crate::clients::handle;
 use crate::models::identifiers::{Identifier, OpenLibraryIdentifer};
 use crate::models::works::Work;
 use crate::OpenLibraryError;
@@ -23,6 +23,6 @@ impl WorksClient {
             .host
             .join(format!("/works/{}.json", identifier.value()).as_str())?;
 
-        get(&self.client, url).await
+        handle(self.client.get(url)).await
     }
 }

--- a/src/models/authors.rs
+++ b/src/models/authors.rs
@@ -1,3 +1,4 @@
+use crate::models::OpenLibraryModel;
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
@@ -26,3 +27,5 @@ pub struct AuthorResponse {
     pub num_found_exact: bool,
     pub docs: Vec<Author>,
 }
+
+impl OpenLibraryModel for AuthorResponse {}

--- a/src/tests/clients.rs
+++ b/src/tests/clients.rs
@@ -1,4 +1,4 @@
-use crate::clients::get;
+use crate::clients::handle;
 use crate::models::OpenLibraryModel;
 use crate::OpenLibraryError;
 use http::{Method, StatusCode};
@@ -31,7 +31,7 @@ pub async fn test_get_returns_successfully() -> Result<(), Box<dyn Error>> {
         .mount(&server)
         .await;
 
-    let actual: FakeResponse = get(&Client::new(), base_url.join(url_path)?).await?;
+    let actual: FakeResponse = handle(Client::new().get(base_url.join(url_path)?)).await?;
 
     assert_eq!(actual, expected);
     Ok(())
@@ -49,7 +49,7 @@ pub async fn test_get_returns_error_when_receives_invalid_json() -> Result<(), B
         .mount(&server)
         .await;
 
-    let response = get::<FakeResponse>(&Client::new(), base_url.join(url_path)?).await;
+    let response = handle::<FakeResponse>(Client::new().get(base_url.join(url_path)?)).await;
     let actual =
         response.expect_err("Expected call to return error but it completed successfully!");
 
@@ -71,7 +71,7 @@ pub async fn test_get_returns_error_when_api_responds_with_error() -> Result<(),
         .mount(&server)
         .await;
 
-    let response = get::<FakeResponse>(&Client::new(), base_url.join(url_path)?).await;
+    let response = handle::<FakeResponse>(Client::new().get(base_url.join(url_path)?)).await;
     let actual =
         response.expect_err("Expected call to return error but it completed successfully!");
 


### PR DESCRIPTION
## Description

Integrating the common API response handling with the rest of the existing routes. 

## Implementation Notes

Made the existing common API response handling a bit more generic to allow for better use of the existing `RequestBuilder`, but supplying query parameters, etc. 

## Issues
Closes #35 