### PR TITLE
Patching Create Release Action

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           command: install
           args: cargo-release
+      - uses: actions/checkout@v2
       - uses: actions-rs/cargo@v1
         with:
           command: release


### PR DESCRIPTION
### Description
 
Fixing an issue with the Create Release action by ensuring that the repository is checked out before running `cargo release`.