### PR TITLE
Consolidating Work Model

### DIFF
--- a/examples/book-cli/src/main.rs
+++ b/examples/book-cli/src/main.rs
@@ -1,7 +1,7 @@
 use crate::arguments::Arguments;
 use anyhow::Result;
 use open_library::models::books::BibliographyKey::{ISBN, LCCN, OCLC, OLID};
-use open_library::models::books::{BibliographyKey, BookIdentifierKey};
+use open_library::models::books::{BibliographyKey};
 use open_library::OpenLibraryClient;
 use structopt::StructOpt;
 use tokio;
@@ -20,6 +20,6 @@ async fn main() -> Result<()> {
 
     let identifiers: Vec<BibliographyKey> = isbn.chain(oclc).chain(lccn).chain(olid).collect();
 
-    println!("{:?}", client.books.search(&identifiers).await?);
+    println!("{:?}", client.books.search(identifiers).await?);
     Ok(())
 }

--- a/src/clients/tests/resources/work.json
+++ b/src/clients/tests/resources/work.json
@@ -1,86 +1,42 @@
 {
-  "publishers": [
-    "Puffin"
+  "lc_classifications": [
+    "KFM9446 .S74"
   ],
-  "number_of_pages": 96,
-  "isbn_10": [
-    "0140328726"
-  ],
-  "covers": [
-    8739161
-  ],
-  "key": "/books/OL7353617M",
-  "authors": [
-    {
-      "key": "/authors/OL34184A"
-    }
-  ],
-  "ocaid": "fantasticmrfoxpu00roal",
-  "contributions": [
-    "Tony Ross (Illustrator)"
-  ],
-  "languages": [
-    {
-      "key": "/languages/eng"
-    }
-  ],
-  "classifications": {},
-  "source_records": [
-    "ia:fantasticmrfox00dahl_834",
-    "marc:marc_openlibraries_sanfranciscopubliclibrary/sfpl_chq_2018_12_24_run02.mrc:85081404:4525"
-  ],
-  "title": "Fantastic Mr. Fox",
-  "identifiers": {
-    "goodreads": [
-      "1507552"
-    ],
-    "librarything": [
-      "6446"
-    ]
-  },
-  "isbn_13": [
-    "9780140328721"
-  ],
-  "local_id": [
-    "urn:sfpl:31223064402481",
-    "urn:sfpl:31223117624784",
-    "urn:sfpl:31223113969183",
-    "urn:sfpl:31223117624800",
-    "urn:sfpl:31223113969225",
-    "urn:sfpl:31223106484539",
-    "urn:sfpl:31223117624792",
-    "urn:sfpl:31223117624818",
-    "urn:sfpl:31223117624768",
-    "urn:sfpl:31223117624743",
-    "urn:sfpl:31223113969209",
-    "urn:sfpl:31223117624750",
-    "urn:sfpl:31223117624727",
-    "urn:sfpl:31223117624776",
-    "urn:sfpl:31223117624719",
-    "urn:sfpl:31223117624735",
-    "urn:sfpl:31223113969241"
-  ],
-  "publish_date": "October 1, 1988",
-  "works": [
-    {
-      "key": "/works/OL45883W"
-    }
-  ],
-  "type": {
-    "key": "/type/edition"
-  },
-  "first_sentence": {
-    "type": "/type/text",
-    "value": "And these two very old people are the father and mother of Mrs. Bucket."
-  },
-  "latest_revision": 14,
-  "revision": 14,
+  "key": "/works/OL3616800W",
   "created": {
     "type": "/type/datetime",
-    "value": "2008-04-29T13:35:46.876380"
+    "value": "2009-12-10T03:59:51.542961"
   },
+  "title": "Selected aspects of Montana water law",
+  "id": 38792925,
+  "subject_places": [
+    "Montana"
+  ],
+  "first_publish_date": "1978",
+  "latest_revision": 2,
   "last_modified": {
     "type": "/type/datetime",
-    "value": "2021-06-18T22:46:46.648233"
-  }
+    "value": "2010-02-17T04:56:51.784573"
+  },
+  "authors": [
+    {
+      "type": "/type/author_role",
+      "author": {
+        "key": "/authors/OL614999A"
+      }
+    }
+  ],
+  "dewey_number": [
+    "346/.786/04691"
+  ],
+  "type": {
+    "key": "/type/work"
+  },
+  "subjects": [
+    "Water",
+    "Water rights",
+    "Law and legislation",
+    "Riparian rights"
+  ],
+  "revision": 2
 }

--- a/src/clients/tests/works.rs
+++ b/src/clients/tests/works.rs
@@ -31,3 +31,5 @@ async fn test_works_get_returns_success() -> Result<(), Box<dyn Error>> {
     assert_eq!(actual, mock_response);
     Ok(())
 }
+
+//TODO write a test for the different options for field values (Author Type)

--- a/src/clients/works.rs
+++ b/src/clients/works.rs
@@ -18,10 +18,10 @@ impl WorksClient {
         }
     }
 
-    pub async fn get(&self, identifier: &OpenLibraryIdentifier) -> Result<Work, OpenLibraryError> {
+    pub async fn get<'a, T: Into<&'a OpenLibraryIdentifier>>(&self, identifier: T) -> Result<Work, OpenLibraryError> {
         let url = self
             .host
-            .join(format!("/works/{}.json", identifier.value()).as_str())?;
+            .join(format!("/works/{}.json", identifier.into().value()).as_str())?;
 
         handle(self.client.get(url)).await
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -70,9 +70,9 @@ pub mod date_m_dd_yyyy {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-struct KeyedValue<T> {
-    key: T,
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KeyedValue<T> {
+    pub key: T,
 }
 
 pub mod keyed_value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub struct OpenLibraryAuthClient {
 }
 
 impl OpenLibraryAuthClient {
+    //TODO: this is odd to consume with having to know to pass in None to get production url
     pub fn new(host: Option<Url>) -> Result<OpenLibraryAuthClient, OpenLibraryError> {
         let client = ClientBuilder::new()
             .build()

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Display, Formatter};
+use crate::models::identifiers::OpenLibraryIdentifier;
+use std::str::FromStr;
 
 pub mod account;
 pub mod authors;
@@ -16,6 +18,17 @@ pub enum OpenLibraryResource {
     Author(String),
     Book(String),
     Work(String),
+}
+
+
+impl OpenLibraryResource {
+    pub fn value(&self) -> String {
+        match self {
+            OpenLibraryResource::Author(value) => value,
+            OpenLibraryResource::Book(value) => value,
+            OpenLibraryResource::Work(value) => value
+        }.clone()
+    }
 }
 
 impl Display for OpenLibraryResource {
@@ -74,6 +87,12 @@ impl Serialize for OpenLibraryResource {
         S: Serializer,
     {
         serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl From<OpenLibraryResource> for OpenLibraryIdentifier {
+    fn from(resource: OpenLibraryResource) -> Self {
+        Self::from_str(&resource.value()).unwrap()
     }
 }
 

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,0 +1,66 @@
+# Models 
+
+## Works 
+
+### Field Frequency
+
+The existence of certain fields were found to vary by record. To understand the impacts, 
+the following is a frequency distribution over 10 million records:  
+
+| Field Name         | Existence Frequency |
+|--------------------|---------------------|
+| created            | 100%                |
+| last_modified      | 100%                |
+| latest_revision    | 100%                |
+| key                | 100%                |
+| type               | 100%                |
+| revision           | 100%                |
+| title              | 99.99%              |
+| authors            | 95.23%              |
+| subjects           | 58.8%               |
+| covers             | 32.0%               |
+| subject_places     | 24.7%               |
+| first_publish_date | 18.57%              |
+| id                 | 13.47%              |
+| lc_classifications | 9.9%                |
+| subject_people     | 7.7                 |
+| subject_times      | 6.07                |
+| dewey_number       | 4.8%                |
+| description        | 4.4%                |
+| subtitle           | 2.4%                |
+| links              | 0.19%               |
+| first_sentence     | 0.3%                |
+| excerpts           | 0.2%                |
+| cover_edition      | 0.008%              |
+| location           | 0.0002%             |
+
+This client is choosing not to support fields with less than 20% frequency until there is an explicit
+reason to do so. 
+
+### Data Quality Issues
+
+1. There is one record in the Data Dump (`OL25303131W`) that doesn't have a title. However,
+this seems to be "fixed" via the API responses. 
+2. There are a number of fields that only 1 record has: 
+   1. `original_languages`
+   2. `table_of_contents`
+   3. `number_of_editions`
+   4. `notes`
+   5. `notifications`
+3. The `description` field has inconsistent data format.
+
+   **Example**:
+
+   | Identifier | Data Type | Value                                   |
+   |------------|-----------|-----------------------------------------|
+   | OL499789W  | object    | { "type": "/type/text", "value" "..." } |
+   | OL39625W   | string    | "..."                                   |
+
+4. The `type` within the `authors` array has an inconsistent data format
+
+   **Example**:
+
+   | Identifier | Data Type | Value                                   |
+   |------------|-----------|-----------------------------------------|
+   | OL499789W  | object    | { "type": "/type/text", "value" "..." } |
+   | OL39625W   | string    | "..."                                   |

--- a/src/models/books.rs
+++ b/src/models/books.rs
@@ -224,14 +224,16 @@ impl FromStr for BookIdentifierKey {
     }
 }
 
+//TODO: this is a duplicate struct name
+// and also wrong
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Author {
     #[serde(skip_serializing_if = "Option::is_none")]
-    key: Option<OpenLibraryResource>,
+    pub key: Option<OpenLibraryResource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    url: Option<String>,
+    pub url: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/models/works.rs
+++ b/src/models/works.rs
@@ -1,49 +1,32 @@
-use crate::models::books::{Author, BookIdentifierKey, Classifications};
-use crate::models::identifiers::InternationalStandardBookNumber;
 use crate::models::{OpenLibraryModel, OpenLibraryResource};
 use chrono::NaiveDate;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize, Deserializer};
+use crate::models::authors::{AuthorReference, AuthorType};
+use crate::format::KeyedValue;
 
+/// Represents a logical collection of similar Editions.
+// The fields present per Work varies by instance so to better understand the distribution a key
+// frequency distribution was created with 10 million records. This client won't support anything
+// over 20% until a reason to do so presents itself. For a detailed view of field frequencies, view
+// `models` directory README.
 #[derive(Deserialize, Debug, Eq, PartialEq, Serialize)]
 pub struct Work {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub publishers: Vec<String>,
-    pub number_of_pages: u32,
-    #[serde(rename = "isbn_10")]
-    pub isbns_10: Vec<InternationalStandardBookNumber>,
-    pub covers: Vec<u32>, //TODO Cover Id
-    pub key: OpenLibraryResource,
-    pub authors: Vec<Author>,
-    pub ocaid: String,
-    pub contributions: Vec<String>,
-    #[serde(with = "crate::format::keyed_list")]
-    pub languages: Vec<String>,
-    pub classifications: Classifications,
-    pub source_records: Vec<String>, //TODO Parse these?
     pub title: String,
     #[serde(default)]
-    pub identifiers: HashMap<BookIdentifierKey, Vec<String>>,
-    #[serde(rename = "isbn_13")]
-    pub isbns_13: Vec<InternationalStandardBookNumber>,
-    pub local_id: Vec<String>, //TODO Parse?
-    #[serde(with = "crate::format::date_m_dd_yyyy")]
-    pub publish_date: NaiveDate,
-    #[serde(with = "crate::format::keyed_list")]
-    pub works: Vec<OpenLibraryResource>,
-    #[serde(rename = "type")]
-    #[serde(with = "crate::format::keyed_value")]
-    pub works_type: String,
-    pub first_sentence: FirstSentence,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub covers: Vec<i32>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subject_places: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subjects: Vec<String>,
+    pub key: OpenLibraryResource,
+    pub authors: Vec<AuthorReference>,
     pub latest_revision: u32,
-}
-
-#[derive(Deserialize, Debug, Eq, PartialEq, Serialize)]
-pub struct FirstSentence {
-    #[serde(rename = "type")]
-    pub sentence_type: String,
-    pub value: String,
+    pub revision: u32,
+    // pub created: TODO need to support
+    // pub last_modified TODO need to support
 }
 
 impl OpenLibraryModel for Work {}


### PR DESCRIPTION
## Description

Currently, there was two different models trying to return `Work` model. Getting the `Work` by identifier and listing the `Work` objects by Author. This PR consolidates them into the same model. 

### Field Frequencies 

It was getting unweidy to understand which fields needed to be optional / which actually existed on the model. Took a statistical approach and generated a frequency map based on 10 million records. Determined which fields we should support via typing. 